### PR TITLE
MAINT: bump development version 0.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-optislang-core"
-version = "0.1.dev0"
+version = "0.2.dev0"
 description = "A python wrapper for ansys optislang application."
 readme = "README.rst"
 requires-python = ">=3.7"


### PR DESCRIPTION
Now that 0.1 was released internally, the minor development version should increase by one unit. 