### PR TITLE
Rename _logger -> log in Optislang() class and api documentation.

### DIFF
--- a/doc/source/api/logging.rst
+++ b/doc/source/api/logging.rst
@@ -9,7 +9,7 @@ For these two types of loggers, the default log message format is:
 
     >>> from ansys.optislang.core import Optislang
     >>> osl = Optislang(loglevel='INFO')
-    >>> osl._logger.info('This is an useful message')
+    >>> osl.log.info('This is an useful message')
     
 .. code:: bash
 

--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -92,7 +92,7 @@ class Optislang:
         self.__name = name
         self.__password = password
 
-        self._logger = LOG.add_instance_logger(self.name, self, loglevel)
+        self.log = LOG.add_instance_logger(self.name, self, loglevel)
         self.__osl_server: OslServer = self.__init_osl_server("tcp")
 
     def __init_osl_server(self, server_type: str) -> OslServer:
@@ -124,7 +124,7 @@ class Optislang:
                 no_save=self.__no_save,
                 ini_timeout=self.__ini_timeout,
                 password=self.__password,
-                logger=self._logger,
+                logger=self.log,
             )
         else:
             raise NotImplementedError(f'OptiSLang server of type "{server_type}" is not supported.')


### PR DESCRIPTION
- [x] Rename logger in Optislang() class

- [x] Edit documentation