### PR TITLE
Maint/osl process args

### DIFF
--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -12,6 +12,7 @@ API documentation.
    :hidden:
 
    optislang
+   osl_process
    project
    nodes
    project_parametric

--- a/doc/source/api/osl_process.rst
+++ b/doc/source/api/osl_process.rst
@@ -1,0 +1,12 @@
+optiSLang process
+=================
+These classes are specific to the :mod:`ansys.optislang.core.osl_process <ansys.optislang.core.osl_process>` module.
+They provide low-level API capability to start and manage optiSLang processes:
+
+.. currentmodule:: ansys.optislang.core.osl_process
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: class.rst
+
+   OslServerProcess

--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, Sequence, Tuple, Union
 
 from importlib_metadata import version
 
@@ -72,6 +72,9 @@ class Optislang:
         Whether to shut down when execution is finished and no listeners are registered.
         The default is ``True``. This parameter is ignored when ``host`` and
         ``port`` parameters are specified.
+    additional_args : Iterable[str], optional
+        Additional command line arguments used for execution of the optiSLang server process.
+        Defaults to ``None``.
 
     Raises
     ------
@@ -103,6 +106,7 @@ class Optislang:
         password: str = None,
         loglevel: str = None,
         shutdown_on_finished: bool = True,
+        additional_args: Iterable[str] = None,
     ) -> None:
         """Initialize a new instance of the ``Optislang`` class."""
         self.__host = host
@@ -114,6 +118,7 @@ class Optislang:
         self.__name = name
         self.__password = password
         self.__shutdown_on_finished = shutdown_on_finished
+        self.__additional_args = additional_args
         self.__logger = LOG.add_instance_logger(self.name, self, loglevel)
         self.__osl_server: OslServer = self.__init_osl_server("tcp")
         project_uid = self.__osl_server.get_project_uid()
@@ -151,6 +156,7 @@ class Optislang:
                 password=self.__password,
                 logger=self.log,
                 shutdown_on_finished=self.__shutdown_on_finished,
+                additional_args=self.__additional_args,
             )
         else:
             raise NotImplementedError(f'OptiSLang server of type "{server_type}" is not supported.')

--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -141,6 +141,11 @@ class Optislang:
 
         .. note:: Only supported in batch mode.
 
+    opx_project_definition_file : Union[str, pathlib.Path], optional
+        Optional path to an OPX project definition file. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
     additional_args : Iterable[str], optional
         Additional command line arguments used for execution of the optiSLang server process.
         Defaults to ``None``.
@@ -190,6 +195,7 @@ class Optislang:
         export_placeholders_file: Union[str, Path] = None,
         output_file: Union[str, Path] = None,
         dump_project_state: Union[str, Path] = None,
+        opx_project_definition_file: Union[str, Path] = None,
         additional_args: Iterable[str] = None,
     ) -> None:
         """Initialize a new instance of the ``Optislang`` class."""
@@ -217,6 +223,7 @@ class Optislang:
         self.__export_placeholders_file = export_placeholders_file
         self.__output_file = output_file
         self.__dump_project_state = dump_project_state
+        self.__opx_project_definition_file = opx_project_definition_file
         self.__additional_args = additional_args
         self.__logger = LOG.add_instance_logger(self.name, self, loglevel)
         self.__osl_server: OslServer = self.__init_osl_server("tcp")
@@ -268,6 +275,7 @@ class Optislang:
                 export_placeholders_file=self.__export_placeholders_file,
                 output_file=self.__output_file,
                 dump_project_state=self.__dump_project_state,
+                opx_project_definition_file=self.__opx_project_definition_file,
                 listener_id=self.__listener_id,
                 multi_listener=self.__multi_listener,
                 additional_args=self.__additional_args,

--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Tuple, Union
 
 from importlib_metadata import version
 
@@ -48,10 +48,48 @@ class Optislang:
         - If the project file does not exist, a project is created in the specified path.
         - If the path is ``None``, a new project is created in the temporary directory.
 
+    batch : bool, optional
+        Determines whether to start optiSLang server in batch mode. Defaults to ``True``.
+    port_range : Tuple[int, int], optional
+        Defines the port range for optiSLang server. Defaults to ``None``.
+    no_run : bool, optional
+        Determines whether not to run the specified project when started in batch mode.
+        Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
     no_save : bool, optional
         Whether to save the specified project after all other actions are completed.
         The default is ``False``. This parameter is ignored when ``host`` and
         ``port`` parameters are specified.
+
+        .. note:: Only supported in batch mode.
+
+    force : bool, optional
+        Determines whether to force opening/processing specified project when started in batch mode
+        even if issues occur.
+        Defaults to ``True``.
+
+        .. note:: Only supported in batch mode.
+
+    reset : bool, optional
+        Determines whether to reset specified project after load.
+        Defaults to ``False``.
+
+        .. note:: Only supported in batch mode.
+
+    auto_relocate : bool, optional
+        Determines whether to automatically relocate missing file paths.
+        Defaults to ``False``.
+
+        .. note:: Only supported in batch mode.
+
+    listener_id : str, optional
+        Specific unique ID for the TCP listener. Defaults to ``None``.
+    multi_listener : Iterable[Tuple[str, int, Optional[str]]], optional
+        Multiple remote listeners (plain TCP/IP based) to be registered at optiSLang server.
+        Each listener is a combination of host, port and (optionally) listener ID.
+        Defaults to ``None``.
     ini_timeout : float, optional
         Time in seconds to connect to the optiSLang server. The default is ``20``.
     name : str, optional
@@ -72,6 +110,37 @@ class Optislang:
         Whether to shut down when execution is finished and no listeners are registered.
         The default is ``True``. This parameter is ignored when ``host`` and
         ``port`` parameters are specified.
+
+        .. note:: Only supported in batch mode.
+
+    env_vars : Mapping[str, str], optional
+        Additional environmental variables (key and value) for the optiSLang server process.
+        Defaults to ``None``.
+    import_project_properties_file : Union[str, pathlib.Path], optional
+        Optional path to a project properties file to import. Defaults to ``None``.
+    export_project_properties_file : Union[str, pathlib.Path], optional
+        Optional path to a project properties file to export. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
+    import_placeholders_file : Union[str, pathlib.Path], optional
+        Optional path to a placeholders file to import. Defaults to ``None``.
+    export_placeholders_file : Union[str, pathlib.Path], optional
+        Optional path to a placeholders file to export. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
+    output_file : Union[str, pathlib.Path], optional
+        Optional path to an output file for writing project run results to. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
+    dump_project_state : Union[str, pathlib.Path], optional
+        Optional path to a project state dump file to export. If a relative path is provided,
+        it is considered to be relative to the project working directory. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
     additional_args : Iterable[str], optional
         Additional command line arguments used for execution of the optiSLang server process.
         Defaults to ``None``.
@@ -100,12 +169,27 @@ class Optislang:
         port: int = None,
         executable: Union[str, Path] = None,
         project_path: Union[str, Path] = None,
+        batch: bool = True,
+        port_range: Tuple[int, int] = None,
+        no_run: bool = None,
         no_save: bool = False,
+        force: bool = True,
+        reset: bool = False,
+        auto_relocate: bool = False,
+        listener_id: str = None,
+        multi_listener: Iterable[Tuple[str, int, Optional[str]]] = None,
         ini_timeout: Union[int, float] = 20,
         name: str = None,
         password: str = None,
         loglevel: str = None,
         shutdown_on_finished: bool = True,
+        env_vars: Mapping[str, str] = None,
+        import_project_properties_file: Union[str, Path] = None,
+        export_project_properties_file: Union[str, Path] = None,
+        import_placeholders_file: Union[str, Path] = None,
+        export_placeholders_file: Union[str, Path] = None,
+        output_file: Union[str, Path] = None,
+        dump_project_state: Union[str, Path] = None,
         additional_args: Iterable[str] = None,
     ) -> None:
         """Initialize a new instance of the ``Optislang`` class."""
@@ -113,11 +197,26 @@ class Optislang:
         self.__port = port
         self.__executable = Path(executable) if executable is not None else None
         self.__project_path = Path(project_path) if project_path is not None else None
+        self.__batch = batch
+        self.__port_range = port_range
+        self.__no_run = no_run
         self.__no_save = no_save
+        self.__force = force
+        self.__reset = reset
+        self.__auto_relocate = auto_relocate
         self.__ini_timeout = ini_timeout
         self.__name = name
         self.__password = password
         self.__shutdown_on_finished = shutdown_on_finished
+        self.__env_vars = env_vars
+        self.__listener_id = listener_id
+        self.__multi_listener = multi_listener
+        self.__import_project_properties_file = import_project_properties_file
+        self.__export_project_properties_file = export_project_properties_file
+        self.__import_placeholders_file = import_placeholders_file
+        self.__export_placeholders_file = export_placeholders_file
+        self.__output_file = output_file
+        self.__dump_project_state = dump_project_state
         self.__additional_args = additional_args
         self.__logger = LOG.add_instance_logger(self.name, self, loglevel)
         self.__osl_server: OslServer = self.__init_osl_server("tcp")
@@ -156,6 +255,21 @@ class Optislang:
                 password=self.__password,
                 logger=self.log,
                 shutdown_on_finished=self.__shutdown_on_finished,
+                batch=self.__batch,
+                port_range=self.__port_range,
+                no_run=self.__no_run,
+                force=self.__force,
+                reset=self.__reset,
+                auto_relocate=self.__auto_relocate,
+                env_vars=self.__env_vars,
+                import_project_properties_file=self.__import_project_properties_file,
+                export_project_properties_file=self.__export_project_properties_file,
+                import_placeholders_file=self.__import_placeholders_file,
+                export_placeholders_file=self.__export_placeholders_file,
+                output_file=self.__output_file,
+                dump_project_state=self.__dump_project_state,
+                listener_id=self.__listener_id,
+                multi_listener=self.__multi_listener,
                 additional_args=self.__additional_args,
             )
         else:

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -748,6 +748,11 @@ class OslServerProcess:
 
         return self.__process.poll() is None
 
+    def wait_for_finished(self):
+        """Wait for the process to finish."""
+        if self.__process is not None and self.is_running():
+            self.__process.wait()
+
     def __start_process_output_thread(self):
         """Start new thread responsible for logging of STDOUT/STDERR of the optiSLang process."""
 

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -149,6 +149,11 @@ class OslServerProcess:
 
         .. note:: Only supported in batch mode.
 
+    opx_project_definition_file : Union[str, pathlib.Path], optional
+        Optional path to an OPX project definition file. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
     additional_args : Iterable[str], optional
         Additional command line arguments used for execution of the optiSLang server process.
         Defaults to ``None``.
@@ -206,6 +211,7 @@ class OslServerProcess:
         export_placeholders_file: Union[str, Path] = None,
         output_file: Union[str, Path] = None,
         dump_project_state: Union[str, Path] = None,
+        opx_project_definition_file: Union[str, Path] = None,
         additional_args: Iterable[str] = None,
     ) -> None:
         """Initialize a new instance of the ``OslServerProcess`` class."""
@@ -256,6 +262,9 @@ class OslServerProcess:
         self.__output_file = self.__class__.__validated_path(output_file, "output_file")
         self.__dump_project_state = self.__class__.__validated_path(
             dump_project_state, "dump_project_state"
+        )
+        self.__opx_project_definition_file = self.__class__.__validated_path(
+            opx_project_definition_file, "opx_project_definition_file"
         )
 
         self.__batch = batch
@@ -609,6 +618,18 @@ class OslServerProcess:
         """
         return self.__dump_project_state
 
+    @property
+    def opx_project_definition_file(self) -> Union[Path, None]:
+        """Path to the OPX project definition file.
+
+        Returns
+        -------
+        Union[pathlib.Path, None]
+            Path to the OPX project definition file, if defined;
+            ``None`` otherwise.
+        """
+        return self.__opx_project_definition_file
+
     def __enter__(self):
         """Enter the context."""
         return self
@@ -645,6 +666,17 @@ class OslServerProcess:
                     args.append(str(self.__project_path))
 
         if self.__batch:
+            if self.__opx_project_definition_file:
+                if IRON_PYTHON:
+                    args.append("--python")
+                    args.append(f'"{str(utils.get_osl_opx_import_script(self.__executable))}"')
+                    args.append("--script-arg")
+                    args.append(f'"{str(self.__opx_project_definition_file)}"')
+                else:
+                    args.append("--python")
+                    args.append(str(utils.get_osl_opx_import_script(self.__executable)))
+                    args.append("--script-arg")
+                    args.append(str(self.__opx_project_definition_file))
             if self.__no_run is None or self.__no_run:
                 # Do not run the specified projects.
                 args.append("--no-run")
@@ -662,25 +694,22 @@ class OslServerProcess:
             if self.__auto_relocate:
                 args.append("--autorelocate")
             if self.__export_project_properties_file is not None:
+                args.append("--export-project-properties")
                 if IRON_PYTHON:
-                    args.append("--export-project-properties")
                     args.append(f'"{str(self.__export_project_properties_file)}"')
                 else:
-                    args.append("--export-project-properties")
                     args.append(str(self.__export_project_properties_file))
             if self.__export_placeholders_file is not None:
+                args.append("--export-values")
                 if IRON_PYTHON:
-                    args.append("--export-values")
                     args.append(f'"{str(self.__export_placeholders_file)}"')
                 else:
-                    args.append("--export-values")
                     args.append(str(self.__export_placeholders_file))
             if self.__output_file is not None:
+                args.append("--output-file")
                 if IRON_PYTHON:
-                    args.append("--output-file")
                     args.append(f'"{str(self.__output_file)}"')
                 else:
-                    args.append("--output-file")
                     args.append(str(self.__output_file))
             if self.__dump_project_state is not None:
                 if IRON_PYTHON:
@@ -736,19 +765,17 @@ class OslServerProcess:
                 args.append(notification.name)
 
         if self.__import_project_properties_file is not None:
+            args.append("--import-project-properties")
             if IRON_PYTHON:
-                args.append("--import-project-properties")
                 args.append(f'"{str(self.__import_project_properties_file)}"')
             else:
-                args.append("--import-project-properties")
                 args.append(str(self.__import_project_properties_file))
 
         if self.__import_placeholders_file is not None:
+            args.append("--import-values")
             if IRON_PYTHON:
-                args.append("--import-values")
                 args.append(f'"{str(self.__import_placeholders_file)}"')
             else:
-                args.append("--import-values")
                 args.append(str(self.__import_placeholders_file))
 
         if self.__additional_args is not None:

--- a/src/ansys/optislang/core/server_commands.py
+++ b/src/ansys/optislang/core/server_commands.py
@@ -591,6 +591,7 @@ def register_listener(
     timeout: int = None,
     notifications: Iterable[str] = None,
     password: str = None,
+    listener_uid: str = None,
 ) -> str:
     """Generate JSON string of register_listener command.
 
@@ -608,6 +609,8 @@ def register_listener(
         Notifications.
     password : str, opt
         Password.
+    listener_uid : str, opt
+        Listener UID.
 
     Returns
     -------
@@ -629,6 +632,8 @@ def register_listener(
         args["timeout"] = timeout
     if notifications is not None:
         args["notifications"] = notifications
+    if listener_uid is not None:
+        args["uid"] = listener_uid
 
     return _to_json(_gen_server_command(command=_REGISTER_LISTENER, args=args, password=password))
 

--- a/src/ansys/optislang/core/tcp_osl_server.py
+++ b/src/ansys/optislang/core/tcp_osl_server.py
@@ -12,7 +12,7 @@ import socket
 import struct
 import threading
 import time
-from typing import Callable, Dict, List, Sequence, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Sequence, Tuple, Union
 import uuid
 
 from ansys.optislang.core import server_commands as commands
@@ -544,6 +544,7 @@ class TcpOslListener:
     Examples
     --------
     Create listener
+
     >>> from ansys.optislang.core.tcp_osl_server import TcpOslListener
     >>> general_listener = TcpOslListener(
     >>>     port_range = (49152, 65535),
@@ -837,6 +838,9 @@ class TcpOslServer(OslServer):
     shutdown_on_finished: bool, optional
         Shut down when execution is finished and there are not any listeners registered.
         It is ignored when the host and port parameters are specified. Defaults to ``True``.
+    additional_args : Iterable[str], optional
+        Additional command line arguments used for execution of the optiSLang server process.
+        Defaults to ``None``.
 
     Raises
     ------
@@ -848,6 +852,7 @@ class TcpOslServer(OslServer):
     Examples
     --------
     Start local optiSLang server, get optiSLang version and shutdown the server.
+
     >>> from ansys.optislang.core.tcp_osl_server import TcpOslServer
     >>> osl_server = TcpOslServer()
     >>> osl_version = osl_server.get_osl_version_string()
@@ -855,6 +860,7 @@ class TcpOslServer(OslServer):
     >>> osl_server.shutdown()
 
     Connect to the remote optiSLang server, get optiSLang version and shutdown the server.
+
     >>> from ansys.optislang.core.tcp_osl_server import TcpOslServer
     >>> host = "192.168.101.1"  # IP address of the remote host
     >>> port = 49200            # Port of the remote optiSLang server
@@ -890,6 +896,7 @@ class TcpOslServer(OslServer):
         password: str = None,
         logger=None,
         shutdown_on_finished=True,
+        additional_args: Iterable[str] = None,
     ) -> None:
         """Initialize a new instance of the ``TcpOslServer`` class."""
         self.__host = host
@@ -911,6 +918,8 @@ class TcpOslServer(OslServer):
         self.__refresh_listeners = threading.Event()
         self.__listeners_refresh_interval = 20
         self.__disposed = False
+        self.__additional_args = additional_args
+
         signal.signal(signal.SIGINT, self.__signal_handler)
         atexit.register(self.dispose)
 
@@ -2190,6 +2199,7 @@ class TcpOslServer(OslServer):
                 ],
                 shutdown_on_finished=shutdown_on_finished,
                 logger=self._logger,
+                additional_args=self.__additional_args,
             )
             self.__osl_process.start()
 

--- a/src/ansys/optislang/core/tcp_osl_server.py
+++ b/src/ansys/optislang/core/tcp_osl_server.py
@@ -12,7 +12,7 @@ import socket
 import struct
 import threading
 import time
-from typing import Callable, Dict, Iterable, List, Sequence, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 import uuid
 
 from ansys.optislang.core import server_commands as commands
@@ -823,9 +823,47 @@ class TcpOslServer(OslServer):
         - If the project file does not exist, a new project is created on the specified path.
         - If the path is None, a new project is created in the temporary directory.
         Defaults to ``None``.
+    batch : bool, optional
+        Determines whether to start optiSLang server in batch mode. Defaults to ``True``.
+    port_range : Tuple[int, int], optional
+        Defines the port range for optiSLang server. Defaults to ``None``.
+    no_run : bool, optional
+        Determines whether not to run the specified project when started in batch mode.
+        Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
     no_save : bool, optional
         Determines whether not to save the specified project after all other actions are completed.
         It is ignored when the host and port parameters are specified. Defaults to ``False``.
+
+        .. note:: Only supported in batch mode.
+
+    force : bool, optional
+        Determines whether to force opening/processing specified project when started in batch mode
+        even if issues occur.
+        Defaults to ``True``.
+
+        .. note:: Only supported in batch mode.
+
+    reset : bool, optional
+        Determines whether to reset specified project after load.
+        Defaults to ``False``.
+
+        .. note:: Only supported in batch mode.
+
+    auto_relocate : bool, optional
+        Determines whether to automatically relocate missing file paths.
+        Defaults to ``False``.
+
+        .. note:: Only supported in batch mode.
+
+    listener_id : str, optional
+        Specific unique ID for the TCP listener. Defaults to ``None``.
+    multi_listener : Iterable[Tuple[str, int, Optional[str]]], optional
+        Multiple remote listeners (plain TCP/IP based) to be registered at optiSLang server.
+        Each listener is a combination of host, port and (optionally) listener ID.
+        Defaults to ``None``.
     ini_timeout : float, optional
         Time in seconds to listen to the optiSLang server port. If the port is not listened
         for specified time, the optiSLang server is not started and RuntimeError is raised.
@@ -838,6 +876,37 @@ class TcpOslServer(OslServer):
     shutdown_on_finished: bool, optional
         Shut down when execution is finished and there are not any listeners registered.
         It is ignored when the host and port parameters are specified. Defaults to ``True``.
+
+        .. note:: Only supported in batch mode.
+
+    env_vars : Mapping[str, str], optional
+        Additional environmental variables (key and value) for the optiSLang server process.
+        Defaults to ``None``.
+    import_project_properties_file : Union[str, pathlib.Path], optional
+        Optional path to a project properties file to import. Defaults to ``None``.
+    export_project_properties_file : Union[str, pathlib.Path], optional
+        Optional path to a project properties file to export. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
+    import_placeholders_file : Union[str, pathlib.Path], optional
+        Optional path to a placeholders file to import. Defaults to ``None``.
+    export_placeholders_file : Union[str, pathlib.Path], optional
+        Optional path to a placeholders file to export. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
+    output_file : Union[str, pathlib.Path], optional
+        Optional path to an output file for writing project run results to. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
+    dump_project_state : Union[str, pathlib.Path], optional
+        Optional path to a project state dump file to export. If a relative path is provided,
+        it is considered to be relative to the project working directory. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
     additional_args : Iterable[str], optional
         Additional command line arguments used for execution of the optiSLang server process.
         Defaults to ``None``.
@@ -891,11 +960,26 @@ class TcpOslServer(OslServer):
         port: int = None,
         executable: Union[str, Path] = None,
         project_path: Union[str, Path] = None,
+        batch: bool = True,
+        port_range: Tuple[int, int] = None,
+        no_run: bool = None,
         no_save: bool = False,
+        force: bool = True,
+        reset: bool = False,
+        auto_relocate: bool = False,
+        listener_id: str = None,
+        multi_listener: Iterable[Tuple[str, int, Optional[str]]] = None,
         ini_timeout: float = 20,
         password: str = None,
         logger=None,
         shutdown_on_finished=True,
+        env_vars: Mapping[str, str] = None,
+        import_project_properties_file: Union[str, Path] = None,
+        export_project_properties_file: Union[str, Path] = None,
+        import_placeholders_file: Union[str, Path] = None,
+        export_placeholders_file: Union[str, Path] = None,
+        output_file: Union[str, Path] = None,
+        dump_project_state: Union[str, Path] = None,
         additional_args: Iterable[str] = None,
     ) -> None:
         """Initialize a new instance of the ``TcpOslServer`` class."""
@@ -910,7 +994,13 @@ class TcpOslServer(OslServer):
 
         self.__executable = Path(executable) if executable is not None else None
         self.__project_path = Path(project_path) if project_path is not None else None
+        self.__batch = batch
+        self.__port_range = port_range
+        self.__no_run = no_run
         self.__no_save = no_save
+        self.__force = force
+        self.__reset = reset
+        self.__auto_relocate = auto_relocate
         self.__password = password
         self.__osl_process = None
         self.__listeners = {}
@@ -918,6 +1008,15 @@ class TcpOslServer(OslServer):
         self.__refresh_listeners = threading.Event()
         self.__listeners_refresh_interval = 20
         self.__disposed = False
+        self.__env_vars = env_vars
+        self.__listener_id = listener_id
+        self.__multi_listener = multi_listener
+        self.__import_project_properties_file = import_project_properties_file
+        self.__export_project_properties_file = export_project_properties_file
+        self.__import_placeholders_file = import_placeholders_file
+        self.__export_placeholders_file = export_placeholders_file
+        self.__output_file = output_file
+        self.__dump_project_state = dump_project_state
         self.__additional_args = additional_args
 
         signal.signal(signal.SIGINT, self.__signal_handler)
@@ -932,6 +1031,7 @@ class TcpOslServer(OslServer):
             listener = self.__create_listener(
                 timeout=self.__timeout,
                 name="Main",
+                uid=self.__listener_id,
             )
             listener.uid = self.__register_listener(
                 host=listener.host,
@@ -2178,7 +2278,9 @@ class TcpOslServer(OslServer):
             raise RuntimeError("optiSLang server is already started.")
 
         listener = self.__create_listener(
-            uid=str(uuid.uuid4()), timeout=self.__timeout, name="Main"
+            uid=self.__listener_id if self.__listener_id else str(uuid.uuid4()),
+            timeout=self.__timeout,
+            name="Main",
         )
         port_queue = Queue()
         listener.add_callback(self.__class__.__port_on_listended, (port_queue, self._logger))
@@ -2193,12 +2295,26 @@ class TcpOslServer(OslServer):
                 password=self.__password,
                 listener=(listener.host, listener.port),
                 listener_id=listener.uid,
+                multi_listener=self.__multi_listener,
                 notifications=[
                     ServerNotification.SERVER_UP,
                     ServerNotification.SERVER_DOWN,
                 ],
                 shutdown_on_finished=shutdown_on_finished,
                 logger=self._logger,
+                batch=self.__batch,
+                port_range=self.__port_range,
+                no_run=self.__no_run,
+                force=self.__force,
+                reset=self.__reset,
+                auto_relocate=self.__auto_relocate,
+                env_vars=self.__env_vars,
+                import_project_properties_file=self.__import_project_properties_file,
+                export_project_properties_file=self.__export_project_properties_file,
+                import_placeholders_file=self.__import_placeholders_file,
+                export_placeholders_file=self.__export_placeholders_file,
+                output_file=self.__output_file,
+                dump_project_state=self.__dump_project_state,
                 additional_args=self.__additional_args,
             )
             self.__osl_process.start()
@@ -2419,6 +2535,7 @@ class TcpOslServer(OslServer):
                 timeout=timeout,
                 notifications=[ntf.name for ntf in notifications],
                 password=self.__password,
+                listener_uid=self.__listener_id,
             )
         )
         return msg[0]["uid"]

--- a/src/ansys/optislang/core/tcp_osl_server.py
+++ b/src/ansys/optislang/core/tcp_osl_server.py
@@ -907,6 +907,11 @@ class TcpOslServer(OslServer):
 
         .. note:: Only supported in batch mode.
 
+    opx_project_definition_file : Union[str, pathlib.Path], optional
+        Optional path to an OPX project definition file. Defaults to ``None``.
+
+        .. note:: Only supported in batch mode.
+
     additional_args : Iterable[str], optional
         Additional command line arguments used for execution of the optiSLang server process.
         Defaults to ``None``.
@@ -980,6 +985,7 @@ class TcpOslServer(OslServer):
         export_placeholders_file: Union[str, Path] = None,
         output_file: Union[str, Path] = None,
         dump_project_state: Union[str, Path] = None,
+        opx_project_definition_file: Union[str, Path] = None,
         additional_args: Iterable[str] = None,
     ) -> None:
         """Initialize a new instance of the ``TcpOslServer`` class."""
@@ -1017,6 +1023,7 @@ class TcpOslServer(OslServer):
         self.__export_placeholders_file = export_placeholders_file
         self.__output_file = output_file
         self.__dump_project_state = dump_project_state
+        self.__opx_project_definition_file = opx_project_definition_file
         self.__additional_args = additional_args
 
         signal.signal(signal.SIGINT, self.__signal_handler)
@@ -2315,6 +2322,7 @@ class TcpOslServer(OslServer):
                 export_placeholders_file=self.__export_placeholders_file,
                 output_file=self.__output_file,
                 dump_project_state=self.__dump_project_state,
+                opx_project_definition_file=self.__opx_project_definition_file,
                 additional_args=self.__additional_args,
             )
             self.__osl_process.start()

--- a/src/ansys/optislang/core/utils.py
+++ b/src/ansys/optislang/core/utils.py
@@ -6,7 +6,7 @@ from enum import Enum
 import os
 from pathlib import Path
 import re
-from typing import Dict, Iterable, OrderedDict, Tuple, Union
+from typing import Dict, Iterable, Optional, OrderedDict, Tuple, Union
 
 from ansys.optislang.core import FIRST_SUPPORTED_VERSION
 
@@ -113,6 +113,39 @@ def find_all_osl_exec() -> OrderedDict[int, Tuple[Path, ...]]:
     # another os
     else:
         raise NotImplementedError(f"Unsupported OS {os.name}.")
+
+
+def get_osl_opx_import_script(osl_executable: Union[str, Path] = None) -> Optional[Path]:
+    """Get the path to the optiSLang OPX import script file.
+
+    Parameters
+    ----------
+    osl_executable : Union[str, pathlib.Path], optional
+        optiSLang executable path to use as a reference for locating the import script file.
+        The default is ``None``, in which case the default optiSLang executable file is used.
+
+    Returns
+    -------
+    Tuple[int, pathlib.Path], None
+        Path to the optiSLang OPX import script file, if location succeeded,
+        ``None`` is returned otherwise.
+
+    Raises
+    ------
+    NotImplementedError
+        Raised when the operating system is not supported.
+    """
+    if osl_executable is None:
+        osl_executable = get_osl_exec()[1]
+
+    if osl_executable is not None:
+        osl_opx_import_script_path = (
+            osl_executable.parent / "tools" / "import" / "opx" / "convert_opx_to_opf.py"
+        )
+        if osl_opx_import_script_path.is_file():
+            return osl_opx_import_script_path
+
+    return None
 
 
 def _find_all_osl_exec_in_windows() -> OrderedDict[int, Tuple[Path, ...]]:


### PR DESCRIPTION
- [x] Added possibility to specify additional/generic osl process args
- [x] Fixes to OslServerProcess command line args
- [x] Include OslServerProcess in API docs.
- [x] OslServerProcess: Explicit attribute for osl listener id
- [x] OslServerProcess: Explicit attribute for osl multi listener
- [x] OslServerProcess: Explicit attributes for most commonly used osl comd line args
- [x] Added explicit support for poividing OPX definition files for import