### PR TITLE
Add `service` argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ tests = [
 doc = [
     "ansys-sphinx-theme==0.10.6",
     "matplotlib==3.7.2",
-    "numpydoc==1.5.0",
+    "numpydoc==1.6.0",
     "pypandoc==1.12",
     "Sphinx==7.2.6",
     "sphinx-copybutton==0.5.2",

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -110,7 +110,7 @@ def test_control(optislang: Optislang):
 
     for command in ["start", "restart", "stop_gently", "stop", "reset"]:
         output = node.control(command, wait_for_completion=False)
-        assert isinstance(output, None)
+        assert output is None
         output = node.control(command, timeout=3)
         assert isinstance(output, bool)
 


### PR DESCRIPTION
There are basically 3 ways how to run optiSLang server as I know (batch/GUI/service). 

- The default behavior of pyOptiSLang is to start in batch mode (arg `batch=True`).
  - Therefore, the default value of `service` arg must be `False` as these modes cannot be run in combination.

- User would have to specify both arguments (`batch=False, service=True`) to start server in service mode.
  - Therefore,  the `service` arg was implemented to override the `batch` arg (`batch=batch if not service else False`)
 
- If user wants to start server in GUI mode, only `batch=False` needs to be set.