### PR TITLE
Add `service` arg.

### DIFF
--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -50,6 +50,15 @@ class Optislang:
 
     batch : bool, optional
         Determines whether to start optiSLang server in batch mode. Defaults to ``True``.
+
+        ..note:: Cannot be used in combination with service mode.
+
+    service: bool, optional
+        Determines whether to start optiSLang server in service mode. If ``True``,
+        ``batch`` argument is set to ``False``. Defaults to ``False``.
+
+        ..note:: Cannot be used in combination with batch mode.
+
     port_range : Tuple[int, int], optional
         Defines the port range for optiSLang server. Defaults to ``None``.
     no_run : bool, optional
@@ -175,6 +184,7 @@ class Optislang:
         executable: Optional[Union[str, Path]] = None,
         project_path: Optional[Union[str, Path]] = None,
         batch: bool = True,
+        service: bool = False,
         port_range: Optional[Tuple[int, int]] = None,
         no_run: Optional[bool] = None,
         no_save: bool = False,
@@ -204,6 +214,7 @@ class Optislang:
         self.__executable = Path(executable) if executable is not None else None
         self.__project_path = Path(project_path) if project_path is not None else None
         self.__batch = batch
+        self.__service = service
         self.__port_range = port_range
         self.__no_run = no_run
         self.__no_save = no_save
@@ -263,6 +274,7 @@ class Optislang:
                 logger=self.log,
                 shutdown_on_finished=self.__shutdown_on_finished,
                 batch=self.__batch,
+                service=self.__service,
                 port_range=self.__port_range,
                 no_run=self.__no_run,
                 force=self.__force,

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -54,6 +54,15 @@ class OslServerProcess:
         Defaults to ``None``.
     batch : bool, optional
         Determines whether to start optiSLang server in batch mode. Defaults to ``True``.
+
+        ..note:: Cannot be used in combination with service mode.
+
+    service: bool, optional
+        Determines whether to start optiSLang server in service mode. If ``True``,
+        ``batch`` argument is set to ``False``. Defaults to ``False``.
+
+        ..note:: Cannot be used in combination with batch mode.
+
     port_range : Tuple[int, int], optional
         Defines the port range for optiSLang server. Defaults to ``None``.
     password : str, optional
@@ -186,6 +195,7 @@ class OslServerProcess:
         executable: Optional[Union[str, Path]] = None,
         project_path: Optional[Union[str, Path]] = None,
         batch: bool = True,
+        service: bool = False,
         port_range: Optional[Tuple[int, int]] = None,
         password: Optional[str] = None,
         no_run: Optional[bool] = None,
@@ -215,6 +225,8 @@ class OslServerProcess:
         additional_args: Optional[Iterable[str]] = None,
     ) -> None:
         """Initialize a new instance of the ``OslServerProcess`` class."""
+        self.__batch = batch if not service else False
+        self.__service = service
         self._logger = logging.getLogger(__name__) if logger is None else logger
         self.__process = None
         self.__handle_process_output_thread = None
@@ -236,7 +248,7 @@ class OslServerProcess:
             raise FileNotFoundError(f"optiSLang executable cannot be found: {executable}")
         else:
             self.__executable = Path(executable)
-        if batch:
+        if self.__batch:
             if project_path is None:
                 self.__tempdir = tempfile.TemporaryDirectory()
                 project_path = Path(self.__tempdir.name) / self.__class__.DEFAULT_PROJECT_FILE
@@ -267,7 +279,6 @@ class OslServerProcess:
             opx_project_definition_file, "opx_project_definition_file"
         )
 
-        self.__batch = batch
         self.__port_range = port_range
         self.__password = password
         self.__no_run = no_run
@@ -650,6 +661,9 @@ class OslServerProcess:
 
         if self.__batch:
             args.append("-b")  # Start batch mode
+
+        if self.__service:
+            args.append("--svc")  # Start service mode
 
         if self.__project_path:
             if not self.__project_path.is_file():

--- a/src/ansys/optislang/core/tcp_osl_server.py
+++ b/src/ansys/optislang/core/tcp_osl_server.py
@@ -825,6 +825,15 @@ class TcpOslServer(OslServer):
         Defaults to ``None``.
     batch : bool, optional
         Determines whether to start optiSLang server in batch mode. Defaults to ``True``.
+
+        ..note:: Cannot be used in combination with service mode.
+
+    service: bool, optional
+        Determines whether to start optiSLang server in service mode. If ``True``,
+        ``batch`` argument is set to ``False``. Defaults to ``False``.
+
+        ..note:: Cannot be used in combination with batch mode.
+
     port_range : Tuple[int, int], optional
         Defines the port range for optiSLang server. Defaults to ``None``.
     no_run : bool, optional
@@ -966,6 +975,7 @@ class TcpOslServer(OslServer):
         executable: Optional[Union[str, Path]] = None,
         project_path: Optional[Union[str, Path]] = None,
         batch: bool = True,
+        service: bool = False,
         port_range: Optional[Tuple[int, int]] = None,
         no_run: Optional[bool] = None,
         no_save: bool = False,
@@ -977,7 +987,7 @@ class TcpOslServer(OslServer):
         ini_timeout: float = 20,
         password: Optional[str] = None,
         logger=None,
-        shutdown_on_finished=True,
+        shutdown_on_finished: bool = True,
         env_vars: Optional[Mapping[str, str]] = None,
         import_project_properties_file: Optional[Union[str, Path]] = None,
         export_project_properties_file: Optional[Union[str, Path]] = None,
@@ -1001,6 +1011,7 @@ class TcpOslServer(OslServer):
         self.__executable = Path(executable) if executable is not None else None
         self.__project_path = Path(project_path) if project_path is not None else None
         self.__batch = batch
+        self.__service = service
         self.__port_range = port_range
         self.__no_run = no_run
         self.__no_save = no_save
@@ -2311,6 +2322,7 @@ class TcpOslServer(OslServer):
                 shutdown_on_finished=shutdown_on_finished,
                 logger=self._logger,
                 batch=self.__batch,
+                service=self.__service,
                 port_range=self.__port_range,
                 no_run=self.__no_run,
                 force=self.__force,


### PR DESCRIPTION
There are basically 3 ways how to run optiSLang server as I know (batch/GUI/service). 

- The default behavior of pyOptiSLang is to start in batch mode (arg `batch=True`).
  - Therefore, the default value of `service` arg must be `False` as these modes cannot be run in combination.

- User would have to specify both arguments (`batch=False, service=True`) to start server in service mode.
  - Therefore,  the `service` arg was implemented to override the `batch` arg (`batch=batch if not service else False`)
 
- If user wants to start server in GUI mode, only `batch=False` needs to be set.