### PR TITLE
Run unit tests with copies of example projects

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import os
 import pathlib
+import shutil
 
 import pytest
 
-from ansys.optislang.core import utils
+from ansys.optislang.core import examples, utils
 
 
 def pytest_addoption(parser):
@@ -91,3 +92,25 @@ def server_info_file(project_file):
     """
     info_file_name = "server_info.ini"
     return get_server_info_file_path(project_file, info_file_name)
+
+
+@pytest.fixture
+def tmp_example_project(tmp_path: pathlib.Path):
+    """Access a temporary copy of an optiSLang project from the examples.
+
+    Assumes the first example file to be an optiSLang project.
+    """
+
+    def _tmp_project(example: str):
+        _, example_files = examples.get_files(example)
+        if example_files is None:
+            raise ValueError(f"No examples files for {example}")
+
+        opf = example_files[0]
+        if opf.suffix != ".opf":
+            raise ValueError(f"Non-existing project file for example {example}")
+
+        shutil.copy(opf, tmp_path)
+        return tmp_path / opf.name
+
+    return _tmp_project

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext as does_not_raise
 import pathlib
 
 import matplotlib.pyplot as plt
@@ -8,51 +7,57 @@ from ansys.optislang.core import examples
 
 pytestmark = pytest.mark.local_osl
 
-run_python_script_examples_dir = (
-    pathlib.Path(__file__).parents[1] / "examples" / "run_python_script"
+
+@pytest.fixture(
+    params=[
+        "01_ten_bar_truss.py",
+        "02_1_oscillator_robustness.py",
+        "02_2_oscillator_python_system.py",
+        "02_3_oscillator_optimization_on_EA.py",
+        "02_4_oscillator_MOP_sensitivity_and_optimization.py",
+        "02_5_oscillator_calibration_systems.py",
+        "03_etk_abaqus.py",
+        # The use of "help" function (intended for interactive use) in this example,
+        # leads to a straying osl process. Deactivate this test for now.
+        # "04_python_node_and_help.py",
+        "05_optimizer_settings.py",
+        "06_sensitivity_settings.py",
+        "07_simple_calculator.py",
+    ]
 )
-
-run_python_script_examples = [
-    "01_ten_bar_truss.py",
-    "02_1_oscillator_robustness.py",
-    "02_2_oscillator_python_system.py",
-    "02_3_oscillator_optimization_on_EA.py",
-    "02_4_oscillator_MOP_sensitivity_and_optimization.py",
-    "02_5_oscillator_calibration_systems.py",
-    "03_etk_abaqus.py",
-    # The use of "help" function (intended for interactive use) in this example,
-    # leads to a straying osl process. Deactivate this test for now.
-    # "04_python_node_and_help.py",
-    "05_optimizer_settings.py",
-    "06_sensitivity_settings.py",
-    "07_simple_calculator.py",
-]
+def run_python_script_example_source(request):
+    """Source of a run_python_script example."""
+    exampe_file = (
+        pathlib.Path(__file__).parents[1] / "examples" / "run_python_script" / request.param
+    )
+    with exampe_file.open() as f:
+        src = f.read()
+    return src
 
 
-@pytest.mark.parametrize("example_script", run_python_script_examples)
-def test_run_python_script_example(example_script):
-    """ """
-    with does_not_raise() as dnr:
-        exec(run_python_script_examples_dir.joinpath(example_script).open().read())
-    assert dnr is None
+@pytest.fixture(params=["01_ten_bar_truss.py"])
+def evaluate_design_example_source(request):
+    """Source of an evaluate_design example."""
+    exampe_file = pathlib.Path(__file__).parents[1] / "examples" / "evaluate_design" / request.param
+    with exampe_file.open() as f:
+        src = f.read()
+    return src
 
 
-def test_01_ten_bar_truss_evaluate_design(monkeypatch, tmp_example_project):
-    """Test 01_ten_bar_truss_evaluate_design.py."""
-    with does_not_raise() as dnr:
-        # Suppress plotting
-        monkeypatch.setattr(plt, "show", lambda: None)
+def test_run_python_script_example(run_python_script_example_source):
+    """Test run_python_script examples."""
+    exec(run_python_script_example_source)
 
-        # Ensure temporary project file within the example script
-        project_file = (None, (tmp_example_project("ten_bar_truss"),))
-        monkeypatch.setattr(examples, "get_files", lambda _: project_file)
 
-        file = (
-            pathlib.Path(__file__).parents[1]
-            / "examples"
-            / "evaluate_design"
-            / "01_ten_bar_truss.py"
-        )
+def test_evaluate_design_01_ten_bar_truss(
+    monkeypatch, tmp_example_project, evaluate_design_example_source
+):
+    """Test evaluate_design examples."""
+    # Suppress plotting
+    monkeypatch.setattr(plt, "show", lambda: None)
 
-        exec(file.open().read())
-        assert dnr is None
+    # Ensure temporary project file within the example script
+    project_file = (None, (tmp_example_project("ten_bar_truss"),))
+    monkeypatch.setattr(examples, "get_files", lambda _: project_file)
+
+    exec(evaluate_design_example_source)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,6 +4,8 @@ import pathlib
 import matplotlib.pyplot as plt
 import pytest
 
+from ansys.optislang.core import examples
+
 pytestmark = pytest.mark.local_osl
 
 run_python_script_examples_dir = (
@@ -35,11 +37,15 @@ def test_run_python_script_example(example_script):
     assert dnr is None
 
 
-@pytest.mark.skip(reason="Execution modifies working tree")
-def test_01_ten_bar_truss_evaluate_design(monkeypatch):
+def test_01_ten_bar_truss_evaluate_design(monkeypatch, tmp_example_project):
     """Test 01_ten_bar_truss_evaluate_design.py."""
     with does_not_raise() as dnr:
+        # Suppress plotting
         monkeypatch.setattr(plt, "show", lambda: None)
+
+        # Ensure temporary project file within the example script
+        project_file = (None, (tmp_example_project("ten_bar_truss"),))
+        monkeypatch.setattr(examples, "get_files", lambda _: project_file)
 
         file = (
             pathlib.Path(__file__).parents[1]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,4 @@
 from contextlib import nullcontext as does_not_raise
-import os
 import pathlib
 
 import matplotlib.pyplot as plt
@@ -7,134 +6,47 @@ import pytest
 
 pytestmark = pytest.mark.local_osl
 
-pytest_path = __file__
-
-run_python_script_examples_dir = os.path.join(
-    pathlib.Path(__file__).parents[1], "examples", "run_python_script"
+run_python_script_examples_dir = (
+    pathlib.Path(__file__).parents[1] / "examples" / "run_python_script"
 )
-run_python_script_example_files_paths = []
-for file in os.listdir(run_python_script_examples_dir):
-    if file.endswith(".py"):
-        run_python_script_example_files_paths.append(
-            os.path.join(run_python_script_examples_dir, file)
-        )
+
+run_python_script_examples = [
+    "01_ten_bar_truss.py",
+    "02_1_oscillator_robustness.py",
+    "02_2_oscillator_python_system.py",
+    "02_3_oscillator_optimization_on_EA.py",
+    "02_4_oscillator_MOP_sensitivity_and_optimization.py",
+    "02_5_oscillator_calibration_systems.py",
+    "03_etk_abaqus.py",
+    # The use of "help" function (intended for interactive use) in this example,
+    # leads to a straying osl process. Deactivate this test for now.
+    # "04_python_node_and_help.py",
+    "05_optimizer_settings.py",
+    "06_sensitivity_settings.py",
+    "07_simple_calculator.py",
+]
 
 
-def test_01_ten_bar_truss():
-    """Test 01_1_ten_bar_truss.py."""
+@pytest.mark.parametrize("example_script", run_python_script_examples)
+def test_run_python_script_example(example_script):
+    """ """
     with does_not_raise() as dnr:
-        name = "01_ten_bar_truss"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
+        exec(run_python_script_examples_dir.joinpath(example_script).open().read())
     assert dnr is None
 
 
-def test_02_1_oscillator_robustness():
-    """Test 02_1_oscillator_robustness.py."""
-    with does_not_raise() as dnr:
-        name = "02_1_oscillator_robustness"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-def test_02_2_oscillator_python_system():
-    """Test 02_2_oscillator_python_system.py."""
-    with does_not_raise() as dnr:
-        name = "02_2_oscillator_python_system"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-def test_02_3_oscillator_optimization_on_EA():
-    """Test 02_3_oscillator_optimization_on_EA.py."""
-    with does_not_raise() as dnr:
-        name = "02_3_oscillator_optimization_on_EA"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-def test_02_4_oscillator_MOP_sensitivity_and_optimization():
-    """Test 02_4_oscillator_MOP_sensitivity_and_optimization.py."""
-    with does_not_raise() as dnr:
-        name = "02_4_oscillator_MOP_sensitivity_and_optimization"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-def test_02_5_oscillator_calibration_systems():
-    """Test 02_5_oscillator_calibration_systems.py."""
-    with does_not_raise() as dnr:
-        name = "02_5_oscillator_calibration_systems"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-def test_03_etk_abaqus():
-    """Test 03_etk_abaqus.py."""
-    with does_not_raise() as dnr:
-        name = "03_etk_abaqus"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-# The use of "help" function (intended for interactive use) in this example,
-# leads to a straying osl process. Deactivate this test for now.
-# def test_04_python_node_and_help():
-#     """Test 04_python_node_and_help.py."""
-#     with does_not_raise() as dnr:
-#         name = "04_python_node_and_help"
-#         file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-#         exec(open(file).read())
-#     assert dnr is None
-
-
-def test_05_optimizer_settings():
-    """Test 05_optimizer_settings.py."""
-    with does_not_raise() as dnr:
-        name = "05_optimizer_settings"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-def test_06_sensitivity_settings():
-    """Test 06_sensitivity_settings.py."""
-    with does_not_raise() as dnr:
-        name = "06_sensitivity_settings"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-def test_07_simple_calculator():
-    """Test 07_simple_calculator.py."""
-    with does_not_raise() as dnr:
-        name = "07_simple_calculator"
-        file = list(filter(lambda path: name in path, run_python_script_example_files_paths))[0]
-        exec(open(file).read())
-    assert dnr is None
-
-
-evaluate_design_examples_dir = os.path.join(
-    pathlib.Path(__file__).parents[1], "examples", "evaluate_design"
-)
-evaluate_design_example_files_paths = []
-for file in os.listdir(evaluate_design_examples_dir):
-    if file.endswith(".py"):
-        evaluate_design_example_files_paths.append(os.path.join(evaluate_design_examples_dir, file))
-
-
+@pytest.mark.skip(reason="Execution modifies working tree")
 def test_01_ten_bar_truss_evaluate_design(monkeypatch):
     """Test 01_ten_bar_truss_evaluate_design.py."""
     with does_not_raise() as dnr:
-        name = "01_ten_bar_truss"
-        file = list(filter(lambda path: name in path, evaluate_design_example_files_paths))[0]
         monkeypatch.setattr(plt, "show", lambda: None)
-        exec(open(file).read())
-    assert dnr is None
+
+        file = (
+            pathlib.Path(__file__).parents[1]
+            / "examples"
+            / "evaluate_design"
+            / "01_ten_bar_truss.py"
+        )
+
+        exec(file.open().read())
+        assert dnr is None

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -3,16 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from ansys.optislang.core import Optislang, examples
+from ansys.optislang.core import Optislang
 from ansys.optislang.core.io import File, FileOutputFormat, RegisteredFile
 from ansys.optislang.core.nodes import Node, ParametricSystem, RootSystem, System
 from ansys.optislang.core.project_parametric import ParameterManager
 
 pytestmark = pytest.mark.local_osl
-calculator_w_parameters = examples.get_files("calculator_with_params")[1][0]
-nested_systems = examples.get_files("nested_systems")[1][0]
-connect_nodes = examples.get_files("nodes_connection")[1][0]
-omdb_files = examples.get_files("omdb_files")[1][0]
 
 
 @pytest.fixture()
@@ -30,9 +26,9 @@ def optislang(scope="function", autouse=False) -> Optislang:
 
 
 # TEST NODE
-def test_node_initialization(optislang: Optislang):
+def test_node_initialization(optislang: Optislang, tmp_example_project):
     """Test `Node` initialization."""
-    optislang.open(file_path=calculator_w_parameters)
+    optislang.open(file_path=tmp_example_project("calculator_with_params"))
     project = optislang.project
     root_system = project.root_system
     node = root_system.get_nodes()[0]
@@ -40,9 +36,9 @@ def test_node_initialization(optislang: Optislang):
     optislang.dispose()
 
 
-def test_node_properties(optislang: Optislang):
+def test_node_properties(optislang: Optislang, tmp_example_project):
     """Test properties of the instance of `Node` class."""
-    optislang.open(file_path=calculator_w_parameters)
+    optislang.open(file_path=tmp_example_project("calculator_with_params"))
     project = optislang.project
     root_system = project.root_system
     node = root_system.get_nodes()[0]
@@ -51,9 +47,9 @@ def test_node_properties(optislang: Optislang):
     optislang.dispose()
 
 
-def test_node_queries(optislang: Optislang):
+def test_node_queries(optislang: Optislang, tmp_example_project):
     """Test get methods of the instance of `Node` class."""
-    optislang.open(file_path=calculator_w_parameters)
+    optislang.open(file_path=tmp_example_project("calculator_with_params"))
     project = optislang.project
     root_system = project.root_system
     node = root_system.find_nodes_by_name("Calculator")[0]
@@ -101,9 +97,9 @@ def test_node_queries(optislang: Optislang):
     optislang.dispose()
 
 
-def test_control(optislang: Optislang):
+def test_control(optislang: Optislang, tmp_example_project):
     """Test control methods of the instance of `Node` class."""
-    optislang.open(file_path=calculator_w_parameters)
+    optislang.open(file_path=tmp_example_project("calculator_with_params"))
     project = optislang.project
     root_system = project.root_system
     node = root_system.find_nodes_by_name("Calculator")[0]
@@ -118,9 +114,9 @@ def test_control(optislang: Optislang):
 
 
 # TEST SYSTEM
-def test_find_node_by_uid(optislang: Optislang):
+def test_find_node_by_uid(optislang: Optislang, tmp_example_project):
     """Test `find_node_by_uid`."""
-    optislang.open(file_path=nested_systems)
+    optislang.open(file_path=tmp_example_project("nested_systems"))
     project = optislang.project
     root_system = project.root_system
 
@@ -177,9 +173,9 @@ def test_find_node_by_uid(optislang: Optislang):
     optislang.dispose()
 
 
-def test_find_node_by_name(optislang: Optislang):
+def test_find_node_by_name(optislang: Optislang, tmp_example_project):
     """Test `find_node_by_name`."""
-    optislang.open(file_path=nested_systems)
+    optislang.open(file_path=tmp_example_project("nested_systems"))
     project = optislang.project
     root_system = project.root_system
 
@@ -216,9 +212,9 @@ def test_find_node_by_name(optislang: Optislang):
 
 
 # TEST PARAMETRIC SYSTEM
-def test_get_parameter_manager(optislang: Optislang):
+def test_get_parameter_manager(optislang: Optislang, tmp_example_project):
     """Test initialization and __str__ methods of both `ParametricSystem` and `ParameterManager`."""
-    optislang.open(file_path=nested_systems)
+    optislang.open(file_path=tmp_example_project("nested_systems"))
     project = optislang.project
     root_system = project.root_system
     parametric_system: ParametricSystem = root_system.find_nodes_by_name("Parametric System")[0]
@@ -231,9 +227,9 @@ def test_get_parameter_manager(optislang: Optislang):
     assert dnr is None
 
 
-def test_get_omdb_files(tmp_path: Path):
+def test_get_omdb_files(tmp_example_project):
     """Test `get_omdb_files()` method."""
-    optislang = Optislang(project_path=omdb_files)
+    optislang = Optislang(project_path=tmp_example_project("omdb_files"))
     optislang.set_timeout(30)
     optislang.reset()
     optislang.start()
@@ -254,9 +250,9 @@ def test_get_omdb_files(tmp_path: Path):
     optislang.dispose()
 
 
-def test_save_designs_as(tmp_path: Path):
+def test_save_designs_as(tmp_path: Path, tmp_example_project):
     """Test `save_designs_as` method."""
-    optislang = Optislang(project_path=omdb_files)
+    optislang = Optislang(project_path=tmp_example_project("omdb_files"))
     optislang.set_timeout(30)
     optislang.reset()
     optislang.start()

--- a/tests/test_optislang.py
+++ b/tests/test_optislang.py
@@ -5,11 +5,10 @@ import time
 
 import pytest
 
-from ansys.optislang.core import Optislang, examples
+from ansys.optislang.core import Optislang
 from ansys.optislang.core.project import Project
 
 pytestmark = pytest.mark.local_osl
-parametric_project = examples.get_files("calculator_with_params")[1][0]
 
 
 @pytest.fixture()
@@ -119,9 +118,9 @@ def test_new(optislang: Optislang, tmp_path: Path):
 
 
 @pytest.mark.parametrize("path_type", [str, Path])
-def test_open(optislang: Optislang, path_type):
+def test_open(optislang: Optislang, tmp_example_project, path_type):
     "Test ``open``."
-    project = examples.get_files("simple_calculator")[1][0]
+    project = tmp_example_project("simple_calculator")
     if path_type == str:
         project = str(project)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -4,13 +4,12 @@ import time
 
 import pytest
 
-from ansys.optislang.core import Optislang, examples
+from ansys.optislang.core import Optislang
 from ansys.optislang.core.io import RegisteredFile
 from ansys.optislang.core.nodes import RootSystem
 from ansys.optislang.core.project_parametric import Design, ParameterManager
 
 pytestmark = pytest.mark.local_osl
-calculator_w_parameters = examples.get_files("calculator_with_params")[1][0]
 
 
 @pytest.fixture()
@@ -27,7 +26,7 @@ def optislang(scope="function", autouse=True) -> Optislang:
     return osl
 
 
-def test_project_queries(optislang: Optislang):
+def test_project_queries(optislang: Optislang, tmp_example_project):
     """Test project queries."""
     project = optislang.project
 
@@ -43,7 +42,7 @@ def test_project_queries(optislang: Optislang):
     status = project.get_status()
     assert isinstance(status, str)
 
-    optislang.open(file_path=calculator_w_parameters)
+    optislang.open(file_path=tmp_example_project("calculator_with_params"))
 
     reg_files = project.get_registered_files()
     assert len(reg_files) == 3

--- a/tests/test_project_parametric_managers.py
+++ b/tests/test_project_parametric_managers.py
@@ -1,14 +1,13 @@
 import pytest
 
-from ansys.optislang.core import Optislang, examples
+from ansys.optislang.core import Optislang
 from ansys.optislang.core.project_parametric import MixedParameter, ObjectiveCriterion, Response
 
 pytestmark = pytest.mark.local_osl
-parametric_project = examples.get_files("calculator_with_params")[1][0]
 
 
 @pytest.fixture()
-def optislang(scope="function", autouse=False) -> Optislang:
+def optislang(tmp_example_project, scope="function", autouse=False) -> Optislang:
     """Create Optislang class.
 
     Returns
@@ -16,7 +15,7 @@ def optislang(scope="function", autouse=False) -> Optislang:
     Optislang:
         Connects to the optiSLang application and provides an API to control it.
     """
-    osl = Optislang(project_path=parametric_project)
+    osl = Optislang(project_path=tmp_example_project("calculator_with_params"))
     osl.set_timeout(20)
     return osl
 

--- a/tests/test_rootsystem.py
+++ b/tests/test_rootsystem.py
@@ -2,17 +2,15 @@ from pathlib import Path
 
 import pytest
 
-from ansys.optislang.core import Optislang, examples
+from ansys.optislang.core import Optislang
 from ansys.optislang.core.project_parametric import Design, DesignStatus, DesignVariable
 
 pytestmark = pytest.mark.local_osl
-parametric_project = examples.get_files("calculator_with_params")[1][0]
-parameters_dict = {"a": 5, "b": 10}
 parameters = [DesignVariable("a", 5), DesignVariable("b", 10)]
 
 
 @pytest.fixture()
-def optislang(scope="function", autouse=False) -> Optislang:
+def optislang(tmp_example_project, scope="function", autouse=False) -> Optislang:
     """Create Optislang class.
 
     Returns
@@ -20,7 +18,7 @@ def optislang(scope="function", autouse=False) -> Optislang:
     Optislang:
         Connects to the optiSLang application and provides an API to control it.
     """
-    osl = Optislang(project_path=parametric_project)
+    osl = Optislang(project_path=tmp_example_project("calculator_with_params"))
     osl.set_timeout(20)
     return osl
 

--- a/tests/test_tcp_osl_server.py
+++ b/tests/test_tcp_osl_server.py
@@ -10,7 +10,7 @@ import uuid
 
 import pytest
 
-from ansys.optislang.core import OslServerProcess, errors, examples
+from ansys.optislang.core import OslServerProcess, errors
 import ansys.optislang.core.tcp_osl_server as tos
 
 _host = socket.gethostbyname(socket.gethostname())
@@ -24,7 +24,6 @@ def find_free_port():
 
 
 _msg = '{ "What": "SYSTEMS_STATUS_INFO" }'
-parametric_project = examples.get_files("calculator_with_params")[1][0]
 
 pytestmark = pytest.mark.local_osl
 
@@ -291,10 +290,10 @@ def test_start_stop_listening(
 #     assert dnr is None
 
 
-def test_evaluate_design(tmp_path: Path):
+def test_evaluate_design(tmp_path: Path, tmp_example_project):
     "Test ``evaluate_design``."
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     tcp_osl_server.save_copy(file_path=tmp_path / "test_evaluate_design.opf")
@@ -313,10 +312,10 @@ def test_evaluate_design(tmp_path: Path):
         ("3577cb69-15b9-4ad1-a53c-ac8af8aaea83", errors.OslCommandError),
     ],
 )
-def test_get_actor_info(uid, expected):
+def test_get_actor_info(uid, expected, tmp_example_project):
     """Test ``get_actor_info``."""
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     if expected == errors.OslCommandError:
@@ -336,10 +335,10 @@ def test_get_actor_info(uid, expected):
         ("3577cb69-15b9-4ad1-a53c-ac8af8aaea83", errors.OslCommandError),
     ],
 )
-def test_get_actor_properties(uid, expected):
+def test_get_actor_properties(uid, expected, tmp_example_project):
     """Test ``get_actor_properties``."""
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     if expected == errors.OslCommandError:
@@ -359,10 +358,10 @@ def test_get_actor_properties(uid, expected):
         ("3577cb69-15b9-4ad1-a53c-ac8af8aaea83", errors.OslCommandError),
     ],
 )
-def test_get_actor_states(uid, expected):
+def test_get_actor_states(uid, expected, tmp_example_project):
     """Test ``get_actor_states``."""
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     if expected == errors.OslCommandError:
@@ -383,10 +382,10 @@ def test_get_actor_states(uid, expected):
         ("3577cb69-15b9-4ad1-a53c-ac8af8aaea83", errors.OslCommandError),
     ],
 )
-def test_get_actor_status_info(uid, expected):
+def test_get_actor_status_info(uid, expected, tmp_example_project):
     """Test ``get_actor_status_info``."""
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     if expected == errors.OslCommandError:
@@ -407,10 +406,10 @@ def test_get_actor_status_info(uid, expected):
         ("3577cb69-15b9-4ad1-a53c-ac8af8aaea83", "can_finalize", errors.OslCommandError),
     ],
 )
-def test_get_actor_supports(uid, feature_name, expected):
+def test_get_actor_supports(uid, feature_name, expected, tmp_example_project):
     """Test ``get_actor_status_info``."""
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     if expected == errors.OslCommandError:
@@ -452,10 +451,10 @@ def test_get_full_project_tree_with_properties(osl_server_process: OslServerProc
     tcp_osl_server.dispose()
 
 
-def test_get_hpc_licensing_forwarded_environment():
+def test_get_hpc_licensing_forwarded_environment(tmp_example_project):
     """Test ``get_hpc_licensing_forwarded_environment``."""
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     hpc_licensing = tcp_osl_server.get_hpc_licensing_forwarded_environment(
@@ -475,10 +474,10 @@ def test_get_hpc_licensing_forwarded_environment():
         ("3577cb69-15b9-4ad1-a53c-ac8af8aaea83", "0", "OVar", errors.OslCommandError),
     ],
 )
-def test_get_input_slot_value(uid, hid, slot_name, expected):
+def test_get_input_slot_value(uid, hid, slot_name, expected, tmp_example_project):
     """Test ``get_input_slot_value``."""
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     if expected == errors.OslCommandError:
@@ -501,10 +500,10 @@ def test_get_input_slot_value(uid, hid, slot_name, expected):
         ("3577cb69-15b9-4ad1-a53c-ac8af8aaea83", "0", "var", errors.OslCommandError),
     ],
 )
-def test_get_output_slot_value(uid, hid, slot_name, expected):
+def test_get_output_slot_value(uid, hid, slot_name, expected, tmp_example_project):
     """Test ``get_output_slot_value``."""
     osl_server_process = create_osl_server_process(
-        shutdown_on_finished=False, project_path=parametric_project
+        shutdown_on_finished=False, project_path=tmp_example_project("calculator_with_params")
     )
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
     if expected == errors.OslCommandError:
@@ -673,10 +672,10 @@ def test_new(osl_server_process: OslServerProcess, tmp_path: Path):
 
 
 @pytest.mark.parametrize("path_type", [str, Path])
-def test_open(osl_server_process: OslServerProcess, path_type):
+def test_open(osl_server_process: OslServerProcess, tmp_example_project, path_type):
     """Test ``open``."""
     tcp_osl_server = create_tcp_osl_server(osl_server_process)
-    project = examples.get_files("simple_calculator")[1][0]
+    project = tmp_example_project("simple_calculator")
     assert project.is_file()
     if path_type == str:
         project = str(project)


### PR DESCRIPTION
The full test suite runs the optiSLang example projects in the working tree and leaves it dirty with
- Modified project files in case a batch run saves the project
- Auto-saved projects
- optiSLang working directories

PR aims to make the tests run with temporary copies of project files.