### PR TITLE
Store osl version locally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
 ]
 dependencies = [
     "importlib-metadata>=4.0,<7",
-    "psutil>=5.9"
+    "psutil>=5.9",
+    "Deprecated>=1.2.14",
 ]
 
 [project.optional-dependencies]

--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -13,7 +13,7 @@ from ansys.optislang.core.tcp_osl_server import TcpOslServer
 
 if TYPE_CHECKING:
     from ansys.optislang.core.logging import OslCustomAdapter
-    from ansys.optislang.core.osl_server import OslServer
+    from ansys.optislang.core.osl_server import OslServer, OslVersion
 
 
 class Optislang:
@@ -173,7 +173,7 @@ class Optislang:
 
     >>> from ansys.optislang.core import Optislang
     >>> osl = Optislang()
-    >>> osl_version = osl.get_osl_version_string()
+    >>> osl_version = osl.osl_version_string
     >>> print(osl_version)
     >>> osl.dispose()
     """
@@ -363,14 +363,14 @@ class Optislang:
         return self.__osl_server.get_project_uid() is not None
 
     @property
-    def osl_version(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
+    def osl_version(self) -> OslVersion:
         """Version of used optiSLang.
 
         Returns
         -------
-        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
-            optiSLang version as tuple containing
-            major version, minor version, maintenance version and revision.
+        OslVersion
+            optiSLang version as typing.NamedTuple containing
+            major, minor, maintenance and revision versions.
         """
         return self.__osl_server.osl_version
 
@@ -446,15 +446,15 @@ class Optislang:
         """
         return self.__osl_server.get_osl_version_string()
 
-    @deprecated(version="0.5.0", reason="Use :py:attr:`Optislang.osl_version_string` instead.")
-    def get_osl_version(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
+    @deprecated(version="0.5.0", reason="Use :py:attr:`Optislang.osl_version` instead.")
+    def get_osl_version(self) -> OslVersion:
         """Get the optiSLang version in use as a tuple.
 
         Returns
         -------
-        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
-            optiSLang version as tuple contains the
-            major version, minor version, maintenance version, and revision.
+        OslVersion
+            optiSLang version as typing.NamedTuple containing
+            major, minor, maintenance and revision versions.
 
         Raises
         ------
@@ -462,6 +462,8 @@ class Optislang:
             Raised when an error occurs while communicating with the server.
         OslCommandError
             Raised when a command or query fails.
+        RuntimeError
+            Raised when parsing version numbers from string fails.
         TimeoutError
             Raised when the timeout float value expires.
         """

--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Tuple, Union
 
+from deprecated.sphinx import deprecated
 from importlib_metadata import version
 
 from ansys.optislang.core import LOG
@@ -362,6 +363,29 @@ class Optislang:
         return self.__osl_server.get_project_uid() is not None
 
     @property
+    def osl_version(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
+        """Version of used optiSLang.
+
+        Returns
+        -------
+        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
+            optiSLang version as tuple containing
+            major version, minor version, maintenance version and revision.
+        """
+        return self.__osl_server.osl_version
+
+    @property
+    def osl_version_string(self) -> str:
+        """Version of used optiSLang.
+
+        Returns
+        -------
+        str
+            optiSLang version.
+        """
+        return self.__osl_server.osl_version_string
+
+    @property
     def project(self) -> Optional[Project]:
         """Instance of the ``Project`` class.
 
@@ -402,6 +426,7 @@ class Optislang:
         """
         self.__osl_server.dispose()
 
+    @deprecated(version="0.5.0", reason="Use :py:attr:`Optislang.osl_version_string` instead.")
     def get_osl_version_string(self) -> str:
         """Get the optiSLang version in use as a string.
 
@@ -421,12 +446,13 @@ class Optislang:
         """
         return self.__osl_server.get_osl_version_string()
 
-    def get_osl_version(self) -> Tuple[Union[int, None], ...]:
+    @deprecated(version="0.5.0", reason="Use :py:attr:`Optislang.osl_version_string` instead.")
+    def get_osl_version(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
         """Get the optiSLang version in use as a tuple.
 
         Returns
         -------
-        tuple
+        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
             optiSLang version as tuple contains the
             major version, minor version, maintenance version, and revision.
 

--- a/src/ansys/optislang/core/osl_server.py
+++ b/src/ansys/optislang/core/osl_server.py
@@ -3,7 +3,27 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
+
+
+class OslVersion(NamedTuple):
+    """optiSLang version.
+
+    Attributes:
+        major: int
+            The major version number.
+        minor: int
+            The minor version number.
+        maintenance: Optional[int]
+            The maintenance version number. ``None`` if not parsed correctly.
+        revision: Optional[int]
+            The revision number. ``None`` if not parsed correctly.
+    """
+
+    major: int
+    minor: int
+    maintenance: Optional[int]
+    revision: Optional[int]
 
 
 class OslServer(ABC):
@@ -17,14 +37,14 @@ class OslServer(ABC):
     @abstractmethod
     def osl_version(
         self,
-    ) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:  # pragma: no cover
+    ) -> OslVersion:  # pragma: no cover
         """Version of used optiSLang.
 
         Returns
         -------
-        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
-            optiSLang version as tuple containing
-            major version, minor version, maintenance version and revision.
+        OslVersion
+            optiSLang version as typing.NamedTuple containing
+            major, minor, maintenance and revision versions.
         """
         pass
 
@@ -449,14 +469,14 @@ class OslServer(ABC):
     @abstractmethod
     def get_osl_version(
         self,
-    ) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:  # pragma: no cover
+    ) -> OslVersion:  # pragma: no cover
         """Get version of used optiSLang.
 
         Returns
         -------
-        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
-            optiSLang version as tuple containing
-            major version, minor version, maintenance version and revision.
+        OslVersion
+            optiSLang version as typing.NamedTuple containing
+            major, minor, maintenance and revision versions.
 
         Raises
         ------
@@ -464,6 +484,8 @@ class OslServer(ABC):
             Raised when an error occurs while communicating with server.
         OslCommandError
             Raised when the command or query fails.
+        RuntimeError
+            Raised when parsing version numbers from string fails.
         TimeoutError
             Raised when the timeout float value expires.
         """

--- a/src/ansys/optislang/core/osl_server.py
+++ b/src/ansys/optislang/core/osl_server.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 
 class OslServer(ABC):
@@ -12,6 +12,33 @@ class OslServer(ABC):
     @abstractmethod
     def __init__(self):
         """``OslServer`` class is an abstract base class and cannot be instantiated."""
+
+    @property
+    @abstractmethod
+    def osl_version(
+        self,
+    ) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:  # pragma: no cover
+        """Version of used optiSLang.
+
+        Returns
+        -------
+        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
+            optiSLang version as tuple containing
+            major version, minor version, maintenance version and revision.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def osl_version_string(self) -> str:  # pragma: no cover
+        """Version of used optiSLang.
+
+        Returns
+        -------
+        str
+            optiSLang version.
+        """
+        pass
 
     @abstractmethod
     def get_server_info(self) -> Dict:  # pragma: no cover
@@ -420,12 +447,14 @@ class OslServer(ABC):
         pass
 
     @abstractmethod
-    def get_osl_version(self) -> Tuple[Union[int, None], ...]:  # pragma: no cover
+    def get_osl_version(
+        self,
+    ) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:  # pragma: no cover
         """Get version of used optiSLang.
 
         Returns
         -------
-        tuple
+        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
             optiSLang version as tuple containing
             major version, minor version, maintenance version and revision.
 

--- a/src/ansys/optislang/core/tcp_osl_server.py
+++ b/src/ansys/optislang/core/tcp_osl_server.py
@@ -1076,12 +1076,12 @@ class TcpOslServer(OslServer):
                 )
 
     @property
-    def osl_version(self) -> Tuple[Optional[int], ...]:
+    def osl_version(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
         """Version of used optiSLang.
 
         Returns
         -------
-        Tuple[Optional[int], ...]
+        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
             optiSLang version as tuple containing
             major version, minor version, maintenance version and revision.
         """
@@ -2249,12 +2249,12 @@ class TcpOslServer(OslServer):
         """
         return self.__port
 
-    def _get_osl_version(self) -> Tuple[Optional[int], ...]:
+    def _get_osl_version(self) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
         """Get version of used optiSLang.
 
         Returns
         -------
-        Tuple[Optional[int], ...]
+        Tuple[Optional[int], Optional[int], Optional[int], Optional[int]]
             optiSLang version as tuple containing
             major version, minor version, maintenance version and revision.
 

--- a/tests/test_optislang.py
+++ b/tests/test_optislang.py
@@ -53,9 +53,9 @@ def test_has_active_project(optislang: Optislang):
     assert dnr is None
 
 
-def test_get_osl_version_string(optislang: Optislang):
-    """Test ``get_osl_version_string``."""
-    version = optislang.get_osl_version_string()
+def test_osl_version_string(optislang: Optislang):
+    """Test ``osl_version_string``."""
+    version = optislang.osl_version_string
     assert isinstance(version, str)
     with does_not_raise() as dnr:
         optislang.dispose()
@@ -63,9 +63,9 @@ def test_get_osl_version_string(optislang: Optislang):
     assert dnr is None
 
 
-def test_get_osl_version(optislang: Optislang):
-    """Test ``get_osl_version``."""
-    major_version, minor_version, maintenance_version, revision = optislang.get_osl_version()
+def test_osl_version(optislang: Optislang):
+    """Test ``osl_version``."""
+    major_version, minor_version, maintenance_version, revision = optislang.osl_version
     assert isinstance(major_version, int)
     assert isinstance(minor_version, int)
     assert isinstance(maintenance_version, int) or maintenance_version == None

--- a/tests/test_tcp_osl_server.py
+++ b/tests/test_tcp_osl_server.py
@@ -291,6 +291,21 @@ def test_start_stop_listening(
 #     assert dnr is None
 
 
+def test_osl_version_properties(osl_server_process: OslServerProcess):
+    """Test ``osl_version`` and ``osl_version_string``."""
+    tcp_osl_server = create_tcp_osl_server(osl_server_process)
+    osl_version = tcp_osl_server.osl_version
+    assert len(osl_version) == 4
+    assert isinstance(osl_version[0], int)
+    assert isinstance(osl_version[1], int)
+    assert isinstance(osl_version[2], int) or osl_version[2] is None
+    assert isinstance(osl_version[3], int) or osl_version[3] is None
+    osl_version_string = tcp_osl_server.osl_version_string
+    assert isinstance(osl_version_string, str)
+    tcp_osl_server.shutdown()
+    tcp_osl_server.dispose()
+
+
 def test_evaluate_design(tmp_path: Path):
     "Test ``evaluate_design``."
     osl_server_process = create_osl_server_process(
@@ -555,28 +570,6 @@ def test_get_basic_project_info(osl_server_process: OslServerProcess):
     tcp_osl_server.dispose()
     assert isinstance(basic_project_info, dict)
     assert bool(basic_project_info)
-
-
-def test_get_osl_version_string(osl_server_process: OslServerProcess):
-    """Test ``get_osl_version_string``."""
-    tcp_osl_server = create_tcp_osl_server(osl_server_process)
-    version = tcp_osl_server.get_osl_version_string()
-    tcp_osl_server.shutdown()
-    tcp_osl_server.dispose()
-    assert isinstance(version, str)
-    assert bool(version)
-
-
-def test_get_osl_version(osl_server_process: OslServerProcess):
-    """Test ``get_osl_version``."""
-    tcp_osl_server = create_tcp_osl_server(osl_server_process)
-    major_version, minor_version, maintenance_version, revision = tcp_osl_server.get_osl_version()
-    tcp_osl_server.shutdown()
-    tcp_osl_server.dispose()
-    assert isinstance(major_version, int)
-    assert isinstance(minor_version, int)
-    assert isinstance(maintenance_version, int) or maintenance_version == None
-    assert isinstance(revision, int) or revision == None
 
 
 def test_get_project_description(osl_server_process: OslServerProcess):


### PR DESCRIPTION
Some functionality dependent on optiSLang version is planned (e. g. `connect_nodes` in version > 24.1 will use server command for connection of inner slots instead of API script). 

- This will reduce unnecessary communication with the server when checking for version.