### PR TITLE
Use of nullcontext in test cases

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext as does_not_raise
 import sys
 
 import pytest
@@ -33,9 +32,7 @@ def test_safe_decode(input, expected):
 
 def test_to_ascii_safe():
     "Test ``to_ascii_safe``."
-    with does_not_raise() as dnr:
-        encoding.to_ascii_safe(test_text_type)
-    assert dnr is None
+    encoding.to_ascii_safe(test_text_type)
 
 
 def test_force_bytes():

--- a/tests/test_optislang.py
+++ b/tests/test_optislang.py
@@ -33,12 +33,10 @@ def optislang(scope="function", autouse=False) -> Optislang:
 #     assert dnr is None
 
 
-# def test_dispose(optislang: Optislang):
-# "Test ``dispose``."
-# with does_not_raise() as dnr:
-# optislang.dispose()
-# time.sleep(3)
-# assert dnr is None
+def test_dispose():
+    "Test ``dispose``."
+    osl = Optislang()
+    osl.dispose()
 
 
 def test_has_active_project(optislang: Optislang):

--- a/tests/test_optislang_termination.py
+++ b/tests/test_optislang_termination.py
@@ -1,5 +1,4 @@
 from contextlib import closing
-from contextlib import nullcontext as does_not_raise
 import os
 from pathlib import Path
 import socket
@@ -108,10 +107,8 @@ def test_local_shutdown_on_finished_false_cm(send_dispose, send_shutdown, osl_no
             osl = None
 
     if not send_shutdown:
-        with does_not_raise() as dnr:
-            osl = Optislang(host="127.0.0.1", port=osl_port, ini_timeout=10)
-            osl.shutdown()
-        assert dnr is None
+        osl = Optislang(host="127.0.0.1", port=osl_port, ini_timeout=10)
+        osl.shutdown()
     else:
         with pytest.raises(
             (
@@ -149,10 +146,8 @@ def test_remote_cm(send_dispose, send_shutdown, osl_none):
             osl = None
 
     if not send_shutdown:
-        with does_not_raise() as dnr:
-            osl = Optislang(host="127.0.0.1", port=osl_server_process.port_range[0], ini_timeout=10)
-            osl.shutdown()
-        assert dnr is None
+        osl = Optislang(host="127.0.0.1", port=osl_server_process.port_range[0], ini_timeout=10)
+        osl.shutdown()
     else:
         with pytest.raises(
             (
@@ -215,10 +210,8 @@ def test_local_shutdown_on_finished_false_wocm(send_dispose, send_shutdown):
         osl.shutdown()
 
     if not send_shutdown:
-        with does_not_raise() as dnr:
-            osl = Optislang(host="127.0.0.1", port=osl_port, ini_timeout=10)
-            osl.shutdown()
-        assert dnr is None
+        osl = Optislang(host="127.0.0.1", port=osl_port, ini_timeout=10)
+        osl.shutdown()
     else:
         with pytest.raises(
             (
@@ -253,10 +246,8 @@ def test_remote_wocm(send_dispose, send_shutdown):
         osl.shutdown()
 
     if not send_shutdown:
-        with does_not_raise() as dnr:
-            osl = Optislang(host="127.0.0.1", port=osl_server_process.port_range[0], ini_timeout=10)
-            osl.shutdown()
-        assert dnr is None
+        osl = Optislang(host="127.0.0.1", port=osl_server_process.port_range[0], ini_timeout=10)
+        osl.shutdown()
     else:
         with pytest.raises(
             (

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,4 @@
-from contextlib import nullcontext as does_not_raise
 from pathlib import Path
-import time
 
 import pytest
 
@@ -23,12 +21,14 @@ def optislang(scope="function", autouse=True) -> Optislang:
     """
     osl = Optislang()
     osl.set_timeout(20)
-    return osl
+    yield osl
+    osl.dispose()
 
 
 def test_project_queries(optislang: Optislang, tmp_example_project):
     """Test project queries."""
     project = optislang.project
+    assert project is not None
 
     description = project.get_description()
     assert isinstance(description, str)
@@ -55,31 +55,25 @@ def test_project_queries(optislang: Optislang, tmp_example_project):
     project_tree = project._get_project_tree()
     assert isinstance(project_tree, list)
 
-    optislang.dispose()
-
 
 def test_project_properties(optislang: Optislang):
     """Test `root_system`, `uid` and `__str__` method."""
     project = optislang.project
+    assert project is not None
+
     uid = project.uid
     assert isinstance(uid, str)
     root_system = project.root_system
     assert isinstance(root_system, RootSystem)
     parameter_manager = project.parameter_manager
     assert isinstance(parameter_manager, ParameterManager)
-    with does_not_raise() as dnr:
-        print(project)
-        optislang.dispose()
-        time.sleep(3)
-    assert dnr is None
 
 
 def test_get_evaluate_design(optislang: Optislang):
     """Test `get_reference_design` and `evaluate_design`."""
     project = optislang.project
+    assert project is not None
     ref_design = project.get_reference_design()
     assert isinstance(ref_design, Design)
     eval_design = project.evaluate_design(design=ref_design)
     assert isinstance(eval_design, Design)
-    optislang.dispose()
-    time.sleep(3)

--- a/tests/test_rootsystem.py
+++ b/tests/test_rootsystem.py
@@ -26,6 +26,7 @@ def optislang(tmp_example_project, scope="function", autouse=False) -> Optislang
 def test_get_reference_design(optislang: Optislang):
     """Test ``get_refence_design``."""
     project = optislang.project
+    assert project is not None
     root_system = project.root_system
     design = root_system.get_reference_design()
     optislang.dispose()
@@ -42,6 +43,7 @@ def test_evaluate_design(optislang: Optislang, tmp_path: Path, update_design: bo
     optislang.save_copy(file_path=tmp_path / "test_modify_parameter.opf")
     optislang.reset()
     project = optislang.project
+    assert project is not None
     root_system = project.root_system
     design = Design(parameters=parameters)
     assert design.status == DesignStatus.IDLE
@@ -94,6 +96,7 @@ def test_evaluate_design(optislang: Optislang, tmp_path: Path, update_design: bo
 def test_design_structure(optislang: Optislang):
     """Test ``get_missing&unused_parameters_names``."""
     project = optislang.project
+    assert project is not None
     root_system = project.root_system
     designs = [
         Design(parameters=parameters),

--- a/tests/test_start_stop_combinations.py
+++ b/tests/test_start_stop_combinations.py
@@ -1,6 +1,4 @@
 """Test different start/stop/stop_gently combinations with Optislang class."""
-from contextlib import nullcontext as does_not_raise
-
 import pytest
 
 from ansys.optislang.core import Optislang
@@ -17,7 +15,9 @@ def optislang() -> Optislang:
     Optislang:
         Connects to the optiSLang application and provides an API to control it.
     """
-    return Optislang()
+    osl = Optislang()
+    yield osl
+    osl.dispose()
 
 
 @pytest.mark.parametrize(
@@ -36,11 +36,8 @@ def optislang() -> Optislang:
 )
 def test_combinations(optislang: Optislang, input, expected):
     "Test combinations."
-    with does_not_raise() as dnr:
-        for method in input:
-            if method[0] == "start":
-                optislang.start(method[1], method[2])
-            if method[0] == "stop":
-                optislang.stop(method[1])
-        optislang.dispose()
-    assert dnr is expected
+    for method in input:
+        if method[0] == "start":
+            optislang.start(method[1], method[2])
+        if method[0] == "stop":
+            optislang.stop(method[1])

--- a/tests/test_start_stop_combinations.py
+++ b/tests/test_start_stop_combinations.py
@@ -21,20 +21,20 @@ def optislang() -> Optislang:
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "input",
     [
-        ((("start", True, True), ("stop", True)), None),  # default
-        ((("start", False, True), ("stop", True)), None),  # don't wait for started -> also default
-        ((("start", True, True), ("stop", False)), None),  # stop: don't wait for finished
-        ((("start", True, False), ("stop", True)), None),  # start: don't wait for finished
-        ((("start", False, False), ("stop", False)), None),  # all false
-        ((("start", True, True), ("stop", True), ("stop", True)), None),
-        ((("start", True, True), ("stop", True), ("start", True, True)), None),
-        ((("stop", True), ("stop", True), ("start", True, True)), None),
-        ((("start", True, True), ("start", True, True), ("start", True, True)), None),
+        (("start", True, True), ("stop", True)),  # default
+        (("start", False, True), ("stop", True)),  # don't wait for started -> also default
+        (("start", True, True), ("stop", False)),  # stop: don't wait for finished
+        (("start", True, False), ("stop", True)),  # start: don't wait for finished
+        (("start", False, False), ("stop", False)),  # all false
+        (("start", True, True), ("stop", True), ("stop", True)),
+        (("start", True, True), ("stop", True), ("start", True, True)),
+        (("stop", True), ("stop", True), ("start", True, True)),
+        (("start", True, True), ("start", True, True), ("start", True, True)),
     ],
 )
-def test_combinations(optislang: Optislang, input, expected):
+def test_combinations(optislang: Optislang, input):
     "Test combinations."
     for method in input:
         if method[0] == "start":


### PR DESCRIPTION
There are a lot of instances where a nullcontext is used around certain assertions. Intention seems to be to ensure that no exceptions are raised. Maybe I'm wrong but it seems redundant since the code is run in pytest. In this PR I removed them for readability.

Also added teardown-in-fixture in some test modules.