### PR TITLE
Maint: Add missing args for various requests

### DIFF
--- a/src/ansys/optislang/core/server_queries.py
+++ b/src/ansys/optislang/core/server_queries.py
@@ -59,13 +59,19 @@ def actor_properties(uid: str, password: Optional[str] = None) -> str:
     return _to_json(_gen_query(what=_ACTOR_PROPERTIES, uid=uid, password=password))
 
 
-def actor_states(uid: str, password: Optional[str] = None) -> str:
+def actor_states(
+    uid: str,
+    include_state_info: bool = True,
+    password: Optional[str] = None,
+) -> str:
     """Generate JSON string of actor_states query.
 
     Parameters
     ----------
     uid: str
         Uid entry.
+    include_state_info: bool
+        Include additional info for each state. Otherwise, only state IDs are returned.
     password : str, opt
         Password.
 
@@ -74,10 +80,19 @@ def actor_states(uid: str, password: Optional[str] = None) -> str:
     str
         JSON string of actor_states query.
     """
-    return _to_json(_gen_query(what=_ACTOR_STATES, uid=uid, password=password))
+    args: QueryArgs = {}
+    args["include_state_info"] = include_state_info
+    return _to_json(_gen_query(what=_ACTOR_STATES, uid=uid, args=args, password=password))
 
 
-def actor_status_info(uid: str, hid: str, password: Optional[str] = None) -> str:
+def actor_status_info(
+    uid: str,
+    hid: str,
+    include_designs: bool = True,
+    include_non_scalar_design_values: bool = False,
+    include_algorithm_info: bool = False,
+    password: Optional[str] = None,
+) -> str:
     """Generate JSON string of actor_status_info query.
 
     Parameters
@@ -86,6 +101,12 @@ def actor_status_info(uid: str, hid: str, password: Optional[str] = None) -> str
         Uid entry.
     hid: str
         Hid entry.
+    include_designs: bool
+        Include (result) designs in status info response.
+    include_non_scalar_design_values: bool
+        Include non scalar values in (result) designs.
+    include_algorithm_info: bool
+        Include algorithm result info in status info response.
     password : str, opt
         Password.
 
@@ -94,7 +115,13 @@ def actor_status_info(uid: str, hid: str, password: Optional[str] = None) -> str
     str
         JSON string of actor_status_info query.
     """
-    return _to_json(_gen_query(what=_ACTOR_STATUS_INFO, uid=uid, hid=hid, password=password))
+    args: QueryArgs = {}
+    args["include_designs"] = include_designs
+    args["include_non_scalar_design_values"] = include_non_scalar_design_values
+    args["include_algorithm_info"] = include_algorithm_info
+    return _to_json(
+        _gen_query(what=_ACTOR_STATUS_INFO, uid=uid, args=args, hid=hid, password=password)
+    )
 
 
 def actor_supports(uid: str, feature_name: str, password=None) -> str:
@@ -135,11 +162,19 @@ def basic_project_info(password: Optional[str] = None) -> str:
     return _to_json(_gen_query(what=_BASIC_PROJECT_INFO, password=password))
 
 
-def full_project_status_info(password: Optional[str] = None) -> str:
+def full_project_status_info(
+    include_non_scalar_design_values: bool = False,
+    include_algorithm_info: bool = False,
+    password: Optional[str] = None,
+) -> str:
     """Generate JSON string of full_project_status_info query.
 
     Parameters
     ----------
+    include_non_scalar_design_values: bool
+        Include non scalar values in (result) designs.
+    include_algorithm_info: bool
+        Include algorithm result info in status info response.
     password : str, opt
         Password.
 
@@ -148,7 +183,10 @@ def full_project_status_info(password: Optional[str] = None) -> str:
     str
         JSON string of full_project_status_info query.
     """
-    return _to_json(_gen_query(what=_FULL_PROJECT_STATUS_INFO, password=password))
+    args: QueryArgs = {}
+    args["include_non_scalar_design_values"] = include_non_scalar_design_values
+    args["include_algorithm_info"] = include_algorithm_info
+    return _to_json(_gen_query(what=_FULL_PROJECT_STATUS_INFO, args=args, password=password))
 
 
 def full_project_tree(password: Optional[str] = None) -> str:
@@ -321,11 +359,22 @@ def server_is_alive(password: Optional[str] = None) -> str:
     return _to_json(_gen_query(what=_SERVER_IS_ALIVE, password=password))
 
 
-def systems_status_info(password: Optional[str] = None) -> str:
+def systems_status_info(
+    include_designs: bool = True,
+    include_non_scalar_design_values: bool = False,
+    include_algorithm_info: bool = False,
+    password: Optional[str] = None,
+) -> str:
     """Generate JSON string of systems_status_info query.
 
     Parameters
     ----------
+    include_designs: bool
+        Include (result) designs in status info response.
+    include_non_scalar_design_values: bool
+        Include non scalar values in (result) designs.
+    include_algorithm_info: bool
+        Include algorithm result info in status info response.
     password : str, opt
         Password.
 
@@ -334,7 +383,11 @@ def systems_status_info(password: Optional[str] = None) -> str:
     str
         JSON string of systems_status_info query.
     """
-    return _to_json(_gen_query(what=_SYSTEMS_STATUS_INFO, password=password))
+    args: QueryArgs = {}
+    args["include_designs"] = include_designs
+    args["include_non_scalar_design_values"] = include_non_scalar_design_values
+    args["include_algorithm_info"] = include_algorithm_info
+    return _to_json(_gen_query(what=_SYSTEMS_STATUS_INFO, args=args, password=password))
 
 
 def _gen_query(

--- a/src/ansys/optislang/core/tcp_osl_server.py
+++ b/src/ansys/optislang/core/tcp_osl_server.py
@@ -1181,7 +1181,11 @@ class TcpOslServer(OslServer):
         """
         return self.send_command(queries.actor_info(uid=uid, password=self.__password))
 
-    def get_actor_states(self, uid: str) -> Dict:
+    def get_actor_states(
+        self,
+        uid: str,
+        include_state_info: bool = True,
+    ) -> Dict:
         """Get available actor states for a certain actor (only the IDs of the available states).
 
         These can be used in conjunction with "get_actor_status_info" to obtain actor status info
@@ -1191,30 +1195,8 @@ class TcpOslServer(OslServer):
         ----------
         uid : str
             Actor uid.
-        Returns
-        -------
-        Dict
-            Info about actor defined by uid.
-        Raises
-        ------
-        OslCommunicationError
-            Raised when an error occurs while communicating with server.
-        OslCommandError
-            Raised when the command or query fails.
-        TimeoutError
-            Raised when the timeout float value expires.
-        """
-        return self.send_command(queries.actor_states(uid=uid, password=self.__password))
-
-    def get_actor_status_info(self, uid: str, hid: str) -> Dict:
-        """Get status info about actor defined by actor uid and state Hid.
-
-        Parameters
-        ----------
-        uid : str
-            Actor uid.
-        hid: str
-            State/Design hierarchical id.
+        include_state_info: bool
+            Include additional info for each state. Otherwise, only state IDs are returned.
         Returns
         -------
         Dict
@@ -1229,7 +1211,57 @@ class TcpOslServer(OslServer):
             Raised when the timeout float value expires.
         """
         return self.send_command(
-            queries.actor_status_info(uid=uid, hid=hid, password=self.__password)
+            queries.actor_states(
+                uid=uid,
+                include_state_info=include_state_info,
+                password=self.__password,
+            )
+        )
+
+    def get_actor_status_info(
+        self,
+        uid: str,
+        hid: str,
+        include_designs: bool = True,
+        include_non_scalar_design_values: bool = False,
+        include_algorithm_info: bool = False,
+    ) -> Dict:
+        """Get status info about actor defined by actor uid and state Hid.
+
+        Parameters
+        ----------
+        uid : str
+            Actor uid.
+        hid: str
+            State/Design hierarchical id.
+        include_designs: bool
+            Include (result) designs in status info response.
+        include_non_scalar_design_values: bool
+            Include non scalar values in (result) designs.
+        include_algorithm_info: bool
+            Include algorithm result info in status info response.
+        Returns
+        -------
+        Dict
+            Info about actor defined by uid.
+        Raises
+        ------
+        OslCommunicationError
+            Raised when an error occurs while communicating with server.
+        OslCommandError
+            Raised when the command or query fails.
+        TimeoutError
+            Raised when the timeout float value expires.
+        """
+        return self.send_command(
+            queries.actor_status_info(
+                uid=uid,
+                hid=hid,
+                include_designs=include_designs,
+                include_non_scalar_design_values=include_non_scalar_design_values,
+                include_algorithm_info=include_algorithm_info,
+                password=self.__password,
+            )
         )
 
     def get_actor_supports(self, uid: str, feature_name: str) -> bool:
@@ -1284,9 +1316,19 @@ class TcpOslServer(OslServer):
         """
         return self.send_command(queries.actor_properties(uid=uid, password=self.__password))
 
-    def get_full_project_status_info(self) -> Dict:
+    def get_full_project_status_info(
+        self,
+        include_non_scalar_design_values: bool = False,
+        include_algorithm_info: bool = False,
+    ) -> Dict:
         """Get full project status info.
 
+        Parameters
+        ----------
+        include_non_scalar_design_values: bool
+            Include non scalar values in (result) designs.
+        include_algorithm_info: bool
+            Include algorithm result info in status info response.
         Returns
         -------
         Dict
@@ -1301,7 +1343,13 @@ class TcpOslServer(OslServer):
         TimeoutError
             Raised when the timeout float value expires.
         """
-        return self.send_command(queries.full_project_status_info(password=self.__password))
+        return self.send_command(
+            queries.full_project_status_info(
+                include_non_scalar_design_values=include_non_scalar_design_values,
+                include_algorithm_info=include_algorithm_info,
+                password=self.__password,
+            )
+        )
 
     def get_full_project_tree(self) -> Dict:
         """Get full project tree.
@@ -1678,9 +1726,22 @@ class TcpOslServer(OslServer):
         is_alive = response_dict.get("status") == "success"
         return is_alive
 
-    def get_systems_status_info(self) -> Dict:
+    def get_systems_status_info(
+        self,
+        include_designs: bool = True,
+        include_non_scalar_design_values: bool = False,
+        include_algorithm_info: bool = False,
+    ) -> Dict:
         """Get project status info, including systems only.
 
+        Parameters
+        ----------
+        include_designs: bool
+            Include (result) designs in status info response.
+        include_non_scalar_design_values: bool
+            Include non scalar values in (result) designs.
+        include_algorithm_info: bool
+            Include algorithm result info in status info response.
         Returns
         -------
         Dict
@@ -1695,7 +1756,14 @@ class TcpOslServer(OslServer):
         TimeoutError
             Raised when the timeout float value expires.
         """
-        return self.send_command(queries.systems_status_info(password=self.__password))
+        return self.send_command(
+            queries.systems_status_info(
+                include_designs=include_designs,
+                include_non_scalar_design_values=include_non_scalar_design_values,
+                include_algorithm_info=include_algorithm_info,
+                password=self.__password,
+            )
+        )
 
     def get_timeout(self) -> Union[float, None]:
         """Get current timeout value for execution of commands.


### PR DESCRIPTION
Added missing args for various requests:
- actor_states:
  -  include_state_info
- actor_status_info:
  -  include_designs
  -  include_non_scalar_design_values
  -  include_algorithm_info
- systems_status_info:
  -  include_designs
  -  include_non_scalar_design_values
  -  include_algorithm_info 
- full_project_status_info:
  -  include_non_scalar_design_values
  -  include_algorithm_info  