### PR TITLE
More typing issues

### DIFF
--- a/src/ansys/optislang/core/nodes.py
+++ b/src/ansys/optislang/core/nodes.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
 
     from ansys.optislang.core.managers import CriteriaManager, ParameterManager, ResponseManager
     from ansys.optislang.core.node_types import NodeType
-    from ansys.optislang.core.osl_server import OslServer
     from ansys.optislang.core.project_parametric import Design
 
 PROJECT_COMMANDS_RETURN_STATES = {
@@ -1571,37 +1570,6 @@ class Slot(ABC):
             Raised when a command or query fails.
         TimeoutError
             Raised when the timeout float value expires.
-        """
-        pass
-
-    @staticmethod
-    @abstractmethod
-    def create_slot(
-        osl_server: OslServer,
-        node: Node,
-        name: str,
-        type_: SlotType,
-        type_hint: Optional[str] = None,
-    ) -> Slot:  # pragma: no cover
-        """Create instance of new slot.
-
-        Parameters
-        ----------
-        osl_server: OslServer
-            Object providing access to the optiSLang server.
-        node : Node
-            Node to which slot belongs to.
-        name : str
-            Slot name.
-        type_ : SlotType
-            Slot type.
-        type_hint : Optional[str], optional
-            Slot's expected data type, by default None.
-
-        Returns
-        -------
-        Slot
-            Instance of InputSlot, OutputSlot, InnerInputSlot or InnerOutputSlot class.
         """
         pass
 

--- a/src/ansys/optislang/core/tcp/managers.py
+++ b/src/ansys/optislang/core/tcp/managers.py
@@ -212,7 +212,7 @@ class TcpCriteriaManagerProxy(CriteriaManager):
             self.__osl_server.set_criterion_property(
                 uid=self.__uid,
                 criterion_name=criterion_name,
-                name=self.__class__.__PROPERTY_MAPPING.get(property_name, property_name),
+                name=self.__PROPERTY_MAPPING.get(property_name, property_name),
                 value=property_value,
             )
 
@@ -304,10 +304,7 @@ class TcpParameterManagerProxy(ParameterManager):
             Raised when the timeout float value expires.
         """
         parameter_manager, container = self.__get_parameter_container()
-        if (
-            self.__class__.__get_parameter_idx(container=container, parameter_name=parameter.name)
-            is not None
-        ):
+        if self.__get_parameter_idx(container=container, parameter_name=parameter.name) is not None:
             raise NameError(
                 f"Parameter `{parameter.name}` already exists, choose another name"
                 " or modify this parameter instead."
@@ -421,7 +418,7 @@ class TcpParameterManagerProxy(ParameterManager):
         idx = self.__get_parameter_idx(container=container, parameter_name=parameter_name)
         if idx is not None:
             container[idx][
-                self.__class__.__PROPERTY_MAPPING.get(property_name, property_name)
+                self.__PROPERTY_MAPPING.get(property_name, property_name)
             ] = property_value
             parameter_manager["parameter_container"] = container
             self.__osl_server.set_actor_property(

--- a/src/ansys/optislang/core/tcp/nodes.py
+++ b/src/ansys/optislang/core/tcp/nodes.py
@@ -3428,10 +3428,10 @@ def _get_node_class_type(node_dict: dict, type_: NodeType) -> NodeClassType:
     """
     # TODO: test
     if node_dict["kind"] == "actor":
-        if type_.subtype in [
-            AddinType.PYTHON_BASED_INTEGRATION_PLUGIN,
-            AddinType.INTEGRATION_PLUGIN,
-        ]:
+        if (
+            type_.subtype == AddinType.PYTHON_BASED_INTEGRATION_PLUGIN
+            or type_.subtype == AddinType.INTEGRATION_PLUGIN
+        ):
             return NodeClassType.INTEGRATION_NODE
         return NodeClassType.NODE
 

--- a/src/ansys/optislang/core/tcp/nodes.py
+++ b/src/ansys/optislang/core/tcp/nodes.py
@@ -30,7 +30,7 @@ import json
 import logging
 from pathlib import Path
 import time
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Type, Union, cast
 
 from deprecated.sphinx import deprecated
 
@@ -357,7 +357,7 @@ class TcpNodeProxy(Node):
         TimeoutError
             Raised when the timeout float value expires.
         """
-        return self._get_slots(type_=SlotType.INPUT, name=name)
+        return cast(Tuple[TcpInputSlotProxy, ...], self._get_slots(type_=SlotType.INPUT, name=name))
 
     def get_name(self) -> str:
         """Get the name of the node.
@@ -405,7 +405,9 @@ class TcpNodeProxy(Node):
         TimeoutError
             Raised when the timeout float value expires.
         """
-        return self._get_slots(type_=SlotType.OUTPUT, name=name)
+        return cast(
+            Tuple[TcpOutputSlotProxy, ...], self._get_slots(type_=SlotType.OUTPUT, name=name)
+        )
 
     def get_parent(self) -> TcpNodeProxy:
         """Get the instance of the parent node.
@@ -2021,7 +2023,10 @@ class TcpParametricSystemProxy(TcpSystemProxy, ParametricSystem):
         TimeoutError
             Raised when the timeout float value expires.
         """
-        return self._get_slots(type_=SlotType.INNER_INPUT, name=name)
+        return cast(
+            Tuple[TcpInnerInputSlotProxy, ...],
+            self._get_slots(type_=SlotType.INNER_INPUT, name=name),
+        )
 
     def get_inner_output_slots(
         self, name: Optional[str] = None
@@ -2047,7 +2052,10 @@ class TcpParametricSystemProxy(TcpSystemProxy, ParametricSystem):
         TimeoutError
             Raised when the timeout float value expires.
         """
-        return self._get_slots(type_=SlotType.INNER_OUTPUT, name=name)
+        return cast(
+            Tuple[TcpInnerOutputSlotProxy, ...],
+            self._get_slots(type_=SlotType.INNER_OUTPUT, name=name),
+        )
 
     def get_omdb_files(self) -> Tuple[File]:
         """Get paths to omdb files.

--- a/src/ansys/optislang/core/tcp/nodes.py
+++ b/src/ansys/optislang/core/tcp/nodes.py
@@ -1626,6 +1626,12 @@ class TcpSystemProxy(TcpNodeProxy, System):
             mop_node_type,
             node_type,
         ) = self._get_subtypes(addin_type=type_.subtype)
+
+        if not isinstance(design_flow, (str, DesignFlow)):
+            raise TypeError(f"Design flow type: `{type(design_flow)}` is not supported.")
+        if isinstance(design_flow, str):
+            design_flow = DesignFlow.from_str(design_flow)
+
         uid = self._osl_server.create_node(
             type_=type_.id,
             name=name,
@@ -1634,7 +1640,7 @@ class TcpSystemProxy(TcpNodeProxy, System):
             mop_node_type=mop_node_type,
             node_type=node_type,
             parent_uid=self.uid,
-            design_flow=self._parse_design_flow(design_flow),
+            design_flow=design_flow.name.lower(),
         )
         info = self._osl_server.get_actor_info(
             uid=uid, include_log_messages=False, include_integrations_registered_locations=False
@@ -1919,33 +1925,6 @@ class TcpSystemProxy(TcpNodeProxy, System):
             raise ValueError(f"Unsupported value of addin_type: ``{addin_type}``.")
 
         return algorithm_type, integration_type, mop_node_type, node_type
-
-    @staticmethod
-    def _parse_design_flow(design_flow: Union[DesignFlow, str, None]) -> Union[str, None]:
-        """Parse ``design_flow`` argument from ``str`` to ``DesignFlow``.
-
-        Parameters
-        ----------
-        design_flow : Union[DesignFlow, str]
-            Argument to be converted.
-
-        Returns
-        -------
-        Union[str, None]
-            Design flow type as string.
-
-        Raises
-        ------
-        TypeError
-            Raised when unsupported type of ``design_flow`` argument was passed.
-        """
-        if design_flow is None:
-            return None
-        if not isinstance(design_flow, (str, DesignFlow)):
-            raise TypeError(f"Design flow type: `{type(design_flow)}` is not supported.")
-        if isinstance(design_flow, str):
-            design_flow = DesignFlow.from_str(design_flow)
-        return design_flow.name.lower()
 
 
 # endregion

--- a/src/ansys/optislang/core/tcp/nodes.py
+++ b/src/ansys/optislang/core/tcp/nodes.py
@@ -914,7 +914,7 @@ class TcpNodeProxy(Node):
                         "is_parametric_system": "ParameterManager" in node.get("properties", {}),
                     }
                 )
-                __class__._find_ancestor_line(  # type: ignore
+                TcpNodeProxy._find_ancestor_line(
                     tree=node,
                     ancestor_line=ancestor_line,
                     node_uid=node_uid,
@@ -972,7 +972,7 @@ class TcpNodeProxy(Node):
             if node["kind"] == "system" and (
                 current_depth < max_search_depth or max_search_depth == -1
             ):
-                __class__._find_nodes_with_name(  # type: ignore
+                TcpNodeProxy._find_nodes_with_name(
                     name=name,
                     tree=node,
                     properties_dicts_list=properties_dicts_list,
@@ -1029,7 +1029,7 @@ class TcpNodeProxy(Node):
             if node["kind"] == "system" and (
                 current_depth < max_search_depth or max_search_depth == -1
             ):
-                __class__._find_node_with_uid(  # type: ignore
+                TcpNodeProxy._find_node_with_uid(
                     uid=uid,
                     tree=node,
                     properties_dicts_list=properties_dicts_list,
@@ -1074,7 +1074,7 @@ class TcpNodeProxy(Node):
                     "kind": node["kind"],
                     "is_parametric_system": "ParameterManager" in node.get("properties", {}),
                 }
-                __class__._find_parent_node_info(  # type: ignore
+                TcpNodeProxy._find_parent_node_info(
                     tree=node,
                     parent_info=new_parent_info,
                     node_uid=node_uid,
@@ -1886,7 +1886,7 @@ class TcpSystemProxy(TcpNodeProxy, System):
             if node["uid"] == uid:
                 nodes_tree.append(node)
             if node["kind"] == "system":
-                __class__._find_subtree(tree=node, uid=uid, nodes_tree=nodes_tree)  # type: ignore
+                TcpSystemProxy._find_subtree(tree=node, uid=uid, nodes_tree=nodes_tree)
         return nodes_tree
 
     @staticmethod
@@ -2859,14 +2859,14 @@ class TcpSlotProxy(Slot):
         if isinstance(from_slot.node, TcpRootSystemProxy):
             from_actor_script = "from_actor = project.get_root_system()\n"
         else:
-            from_actor_script = __class__._create_find_actor_script(  # type: ignore
+            from_actor_script = TcpSlotProxy._create_find_actor_script(
                 node=from_slot.node, name="from_actor"
             )
 
         if isinstance(to_slot.node, TcpRootSystemProxy):
             to_actor_script = "to_actor = project.get_root_system()"
         else:
-            to_actor_script = __class__._create_find_actor_script(  # type: ignore
+            to_actor_script = TcpSlotProxy._create_find_actor_script(
                 node=to_slot.node, name="to_actor"
             )
 

--- a/src/ansys/optislang/core/tcp/osl_server.py
+++ b/src/ansys/optislang/core/tcp/osl_server.py
@@ -433,10 +433,10 @@ class TcpClient:
         with open(file_path, "rb") as file:
             self.__socket.settimeout(timeout)
             self.__socket.sendall(header)
-            load = file.read(self.__class__._BUFFER_SIZE)
+            load = file.read(self._BUFFER_SIZE)
             while load:
                 self.__socket.send(load)
-                load = file.read(self.__class__._BUFFER_SIZE)
+                load = file.read(self._BUFFER_SIZE)
 
     def receive_msg(self, timeout: Optional[float] = 5) -> str:
         """Receive message from the server.
@@ -618,8 +618,8 @@ class TcpClient:
         received_len = 0
         while received_len < count:
             remain = count - received_len
-            if remain > self.__class__._BUFFER_SIZE:
-                buff = self.__class__._BUFFER_SIZE
+            if remain > self._BUFFER_SIZE:
+                buff = self._BUFFER_SIZE
             else:
                 buff = remain
 
@@ -669,8 +669,8 @@ class TcpClient:
             data_len = 0
             while data_len < file_len:
                 remain = file_len - data_len
-                if remain > self.__class__._BUFFER_SIZE:
-                    buff = self.__class__._BUFFER_SIZE
+                if remain > self._BUFFER_SIZE:
+                    buff = self._BUFFER_SIZE
                 else:
                     buff = remain
 
@@ -1224,7 +1224,7 @@ class TcpOslServer(OslServer):
         atexit.register(self.dispose)
 
         if self.__host is None or self.__port is None:
-            self.__host = self.__class__._LOCALHOST
+            self.__host = self._LOCALHOST
             self.__shutdown_on_finished = shutdown_on_finished
             self._start_local(ini_timeout, shutdown_on_finished)
         else:
@@ -3773,9 +3773,9 @@ class TcpOslServer(OslServer):
 
         if isinstance(response, list):
             for resp_elem in response:
-                self.__class__.__check_command_response(resp_elem)
+                self.__check_command_response(resp_elem)
         else:
-            self.__class__.__check_command_response(response)
+            self.__check_command_response(response)
 
         return response
 
@@ -4115,7 +4115,7 @@ class TcpOslServer(OslServer):
         start_time = datetime.now()
         while (
             self.__osl_process.is_running()
-            and (datetime.now() - start_time).seconds < self.__class__._SHUTDOWN_WAIT
+            and (datetime.now() - start_time).seconds < self._SHUTDOWN_WAIT
         ):
             time.sleep(0.5)
 
@@ -4328,7 +4328,7 @@ class TcpOslServer(OslServer):
             optiSLang server port is not listened for specified timeout value.
         """
         listener = TcpOslListener(
-            port_range=self.__class__._PRIVATE_PORTS_RANGE,
+            port_range=self._PRIVATE_PORTS_RANGE,
             timeout=timeout,
             name=name,
             uid=uid,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -44,7 +44,7 @@ def test_create_log_file(tmp_path: Path):
     "This tests creation of logfile with ``logfile_name`` when initialized"
     logfile_path = tmp_path / "testlog.log"
     assert not logfile_path.is_file()
-    log = logging.OslLogger(log_to_file=True, logfile_name=logfile_path)
+    logging.OslLogger(log_to_file=True, logfile_name=str(logfile_path))
     assert logfile_path.is_file()
 
 
@@ -65,8 +65,8 @@ def test_set_log_level():
 
 def test_add_file_handler(tmp_path: Path):
     log = logging.OslLogger()
-    log.add_file_handler(logfile_name=tmp_path / "testlog.log")
-    assert log.file_handler != None
+    log.add_file_handler(logfile_name=str(tmp_path / "testlog.log"))
+    assert log.file_handler is not None
     assert log.file_handler.level == LOG_LEVELS[logging.LOG_LEVEL]
     log.set_log_level(loglevel="ERROR")
     assert log.file_handler.level == deflogging.ERROR
@@ -89,7 +89,7 @@ def test_global_logger_has_handlers():
     "This tests if global logger has handlers"
     assert hasattr(LOG, "file_handler")
     assert hasattr(LOG, "std_out_handler")
-    assert LOG.logger.hasHandlers
+    assert LOG.logger.hasHandlers()
     assert LOG.file_handler or LOG.std_out_handler  # at least a handler is not empty
 
 
@@ -105,7 +105,7 @@ def test_global_logger_stdout(caplog):
 
 def test_global_logger_log_to_file(tmp_path: Path):
     LOG.logger.setLevel("DEBUG")
-    LOG.add_file_handler(logfile_name=tmp_path / "testlog.log", loglevel="DEBUG")
+    LOG.add_file_handler(logfile_name=str(tmp_path / "testlog.log"), loglevel="DEBUG")
     msg = "Random debug message"
     LOG.logger.debug(msg)
     with open(tmp_path / "testlog.log", "r") as fid:


### PR DESCRIPTION
Resolve some more issues with static typing. Reduces error count to 123.

- Call static methods with class name to have them type-checked too
- Access static attributes with `self`
- Remove a problematic method from the interface