### PR TITLE
Revisit loggin module

### DIFF
--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -24,7 +24,6 @@
 from __future__ import annotations
 
 from copy import copy
-from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Optional
 import weakref
@@ -39,7 +38,6 @@ FILE_NAME = "pyOptislang.log"
 ## Formatting
 
 LOG_MSG_FORMAT = "%(levelname)s - %(name)s - %(module)s.%(funcName)s - %(message)s"
-LOG_SESSION_HEADER = f"{datetime.now()} - PyOptiSLang session started"
 
 
 class OslCustomAdapter(logging.LoggerAdapter):
@@ -159,7 +157,6 @@ class OslLogger:
         file_handler.setLevel(loglevel)
         self.logger.addHandler(file_handler)
         self.file_handler = file_handler
-        file_handler.stream.write(LOG_SESSION_HEADER + "\n")
 
     def add_std_out_handler(
         self,
@@ -177,7 +174,6 @@ class OslLogger:
         std_out_handler.setFormatter(logging.Formatter(LOG_MSG_FORMAT))
         self.logger.addHandler(std_out_handler)
         self.std_out_handler = std_out_handler
-        std_out_handler.stream.write(LOG_SESSION_HEADER + "\n")
 
     def create_logger(self, new_logger_name: str, level: Optional[str] = None) -> logging.Logger:
         """Create a logger for the Optislang instance.

--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -37,7 +37,7 @@ FILE_NAME = "pyOptislang.log"
 
 ## Formatting
 
-LOG_MSG_FORMAT = "%(levelname)s - %(name)s - %(module)s.%(funcName)s - %(message)s"
+LOG_MSG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s - %(module)s.%(funcName)s - %(message)s"
 
 
 class OslCustomAdapter(logging.LoggerAdapter):

--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 from copy import copy
 import logging
 from typing import TYPE_CHECKING, Optional
-import weakref
 
 if TYPE_CHECKING:
     from ansys.optislang.core import Optislang
@@ -38,47 +37,6 @@ FILE_NAME = "pyOptislang.log"
 ## Formatting
 
 LOG_MSG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s - %(module)s.%(funcName)s - %(message)s"
-
-
-class OslCustomAdapter(logging.LoggerAdapter):
-    """Provides a customized logger with extra inputs."""
-
-    file_handler = None
-    std_out_handler = None
-    log_level = LOG_LEVEL
-
-    def __init__(
-        self,
-        logger: logging.Logger,
-        extra=None,
-    ) -> None:
-        """
-        Initialize the customized logger with extra inputs.
-
-        Parameters
-        ----------
-        logger : str, optional
-            Level of logging. The default is ``LOG_LEVEL``.
-        """
-        self.logger = logger
-        if extra:
-            self.extra = weakref.proxy(extra)
-        else:
-            self.extra = None
-
-        self.file_handler = logger.file_handler
-        self.std_out_handler = logger.std_out_handler
-
-    def process(self, msg, kwargs):
-        """Modify the message and/or keyword arguments passed to a logging call."""
-        kwargs["extra"] = {}
-        # These are the extra parameters sent to the log.
-        # Here, self.extra is the argument passed to the log records.
-        try:
-            kwargs["extra"]["instance_name"] = self.extra.name
-        except ReferenceError:
-            kwargs["extra"]["instance_name"] = "Undefined"
-        return msg, kwargs
 
 
 class OslLogger:
@@ -187,7 +145,7 @@ class OslLogger:
         Returns
         -------
         logging.logger
-            Logger class.
+            Logger instance.
         """
         new_logger = logging.getLogger(new_logger_name)
         new_logger.std_out_handler = None
@@ -213,7 +171,7 @@ class OslLogger:
 
     def add_instance_logger(
         self, instance_name: str, osl_instance: Optislang, level: Optional[str] = None
-    ) -> OslCustomAdapter:
+    ) -> logging.Logger:
         """Add a logger for an Optislang instance.
 
         Parameters
@@ -228,8 +186,8 @@ class OslLogger:
 
         Returns
         -------
-        OslCustomAdapter
-            Customized logger with extra inputs.
+        logging.Logger
+            Logger instance.
         """
         if type(instance_name) is not str:
             raise ValueError("Expected input instance_name: str")
@@ -241,4 +199,4 @@ class OslLogger:
             counter += 1
             instance_name = name + str(counter)
 
-        return OslCustomAdapter(self.create_logger(instance_name, level), osl_instance)
+        return self.create_logger(instance_name, level)

--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -265,20 +265,3 @@ class OslLogger:
         )
 
         return self.instances[instance_name]
-
-    def __getitem__(self, instance_name: str) -> logging.Logger:
-        """Get a logger by an instance name.
-
-        Parameters
-        ----------
-        instance_name : str
-            Name of the instance.
-        Returns
-        -------
-        self.instances[instance_name]: logging.Logger()
-            Logger class.
-        """
-        if instance_name in self.instances.keys():
-            return self.instances[instance_name]
-        else:
-            raise KeyError(f"There is no instances with name {instance_name}")

--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -38,8 +38,7 @@ FILE_NAME = "pyOptislang.log"
 
 ## Formatting
 
-STDOUT_MSG_FORMAT = "%(levelname)s -  %(module)s - %(name)s -  %(funcName)s - %(message)s"
-FILE_MSG_FORMAT = STDOUT_MSG_FORMAT
+LOG_MSG_FORMAT = "%(levelname)s - %(name)s - %(module)s.%(funcName)s - %(message)s"
 
 DEFAULT_STDOUT_HEADER = """
 LEVEL - MODULE - CLASS - FUNCTION - MESSAGE
@@ -71,8 +70,6 @@ class OslCustomAdapter(logging.LoggerAdapter):
         ----------
         logger : str, optional
             Level of logging. The default is ``LOG_LEVEL``.
-        osl_instance : bool, optional
-            Whether to record logs to an output file. The default is ``True``.
         """
         self.logger = logger
         if extra:
@@ -167,7 +164,7 @@ class OslLogger:
             Level of logging. The default is ``LOG_LEVEL``.
         """
         file_handler = logging.FileHandler(logfile_name)
-        file_handler.setFormatter(logging.Formatter(FILE_MSG_FORMAT))
+        file_handler.setFormatter(logging.Formatter(LOG_MSG_FORMAT))
         file_handler.setLevel(loglevel)
         self.logger.addHandler(file_handler)
         self.file_handler = file_handler
@@ -187,7 +184,7 @@ class OslLogger:
         """
         std_out_handler = logging.StreamHandler()
         std_out_handler.setLevel(loglevel)
-        std_out_handler.setFormatter(logging.Formatter(FILE_MSG_FORMAT))
+        std_out_handler.setFormatter(logging.Formatter(LOG_MSG_FORMAT))
         self.logger.addHandler(std_out_handler)
         self.std_out_handler = std_out_handler
         std_out_handler.stream.write(NEW_SESSION_HEADER)
@@ -236,14 +233,14 @@ class OslLogger:
     ) -> None:
         """Call the ``create_logger`` method to add a child logger.
 
-        This looger is more general than the main logger.
+        This logger is more general than the main logger.
 
         Parameters
         ----------
         child_logger_name : str
             Name of the  child logger.
         """
-        if type(child_logger_name) is not str:
+        if not isinstance(child_logger_name, str):
             raise ValueError("Expected input child_logger_name: str")
         child_logger = self.logger.name + "." + child_logger_name
         self.instances[child_logger] = self.create_logger(child_logger)

--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -87,7 +87,6 @@ class OslLogger:
     file_handler = None
     std_out_handler = None
     log_level = LOG_LEVEL
-    instances = {}
 
     def __init__(
         self,
@@ -212,24 +211,6 @@ class OslLogger:
         new_logger.propagate = True
         return new_logger
 
-    def add_child_logger(
-        self,
-        child_logger_name: str,
-    ) -> None:
-        """Call the ``create_logger`` method to add a child logger.
-
-        This logger is more general than the main logger.
-
-        Parameters
-        ----------
-        child_logger_name : str
-            Name of the  child logger.
-        """
-        if not isinstance(child_logger_name, str):
-            raise ValueError("Expected input child_logger_name: str")
-        child_logger = self.logger.name + "." + child_logger_name
-        self.instances[child_logger] = self.create_logger(child_logger)
-
     def add_instance_logger(
         self, instance_name: str, osl_instance: Optislang, level: Optional[str] = None
     ) -> OslCustomAdapter:
@@ -260,8 +241,4 @@ class OslLogger:
             counter += 1
             instance_name = name + str(counter)
 
-        self.instances[instance_name] = OslCustomAdapter(
-            self.create_logger(instance_name, level), osl_instance
-        )
-
-        return self.instances[instance_name]
+        return OslCustomAdapter(self.create_logger(instance_name, level), osl_instance)

--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -39,16 +39,7 @@ FILE_NAME = "pyOptislang.log"
 ## Formatting
 
 LOG_MSG_FORMAT = "%(levelname)s - %(name)s - %(module)s.%(funcName)s - %(message)s"
-
-DEFAULT_STDOUT_HEADER = """
-LEVEL - MODULE - CLASS - FUNCTION - MESSAGE
-"""
-DEFAULT_FILE_HEADER = DEFAULT_STDOUT_HEADER
-NEW_SESSION_HEADER = f"""
-===============================================================================
-       NEW SESSION - {datetime.now().strftime("%m/%d/%Y, %H:%M:%S")}
-===============================================================================
-"""
+LOG_SESSION_HEADER = f"{datetime.now()} - PyOptiSLang session started"
 
 
 class OslCustomAdapter(logging.LoggerAdapter):
@@ -168,8 +159,7 @@ class OslLogger:
         file_handler.setLevel(loglevel)
         self.logger.addHandler(file_handler)
         self.file_handler = file_handler
-        file_handler.stream.write(NEW_SESSION_HEADER)
-        file_handler.stream.write(DEFAULT_FILE_HEADER)
+        file_handler.stream.write(LOG_SESSION_HEADER + "\n")
 
     def add_std_out_handler(
         self,
@@ -187,8 +177,7 @@ class OslLogger:
         std_out_handler.setFormatter(logging.Formatter(LOG_MSG_FORMAT))
         self.logger.addHandler(std_out_handler)
         self.std_out_handler = std_out_handler
-        std_out_handler.stream.write(NEW_SESSION_HEADER)
-        std_out_handler.stream.write(DEFAULT_STDOUT_HEADER)
+        std_out_handler.stream.write(LOG_SESSION_HEADER + "\n")
 
     def create_logger(self, new_logger_name: str, level: Optional[str] = None) -> logging.Logger:
         """Create a logger for the Optislang instance.

--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -24,6 +24,7 @@
 from __future__ import annotations
 
 from importlib.metadata import version
+from logging import Logger
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Tuple, Union
 
@@ -35,7 +36,6 @@ from ansys.optislang.core.tcp.osl_server import TcpOslServer
 
 if TYPE_CHECKING:
     from ansys.optislang.core.application import Application
-    from ansys.optislang.core.logging import OslCustomAdapter
     from ansys.optislang.core.osl_server import OslServer, OslVersion
     from ansys.optislang.core.project import Project
 
@@ -392,7 +392,7 @@ class Optislang:
         return self.application.project is not None
 
     @property
-    def log(self) -> OslCustomAdapter:
+    def log(self) -> Logger:
         """Instance logger."""
         return self.__logger
 

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -1097,7 +1097,7 @@ class OslServerProcess:
                         if handler:
                             try:
                                 if is_decode:
-                                    line = encoding.force_text(line)
+                                    line = encoding.force_text(line).rstrip()
                                 handler("optiSLang " + name + ": " + line)
                             except:
                                 handler("optiSLang " + name + ": " + line)

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -1029,7 +1029,7 @@ class OslServerProcess:
         decode_streams: bool = True,
         logger=None,
     ):
-        """Handle STDOUT/STDERR of the specified process.
+        """Handle stdout/stderr of the specified process.
 
         Registers for notifications to lean that process output is ready to read, and dispatches
         lines to the respective line handlers. This function returns once the finalizer returns.
@@ -1039,19 +1039,19 @@ class OslServerProcess:
         Parameters
         ----------
         process : subprocess.Popen
-            Process which STDOUT or STDERR is supposed to be handled.
+            Process to read from.
 
         stdout_handler : Callable[[str], None], None
-            Handler for STDOUT.
+            Handler for stdout.
 
         stderr_handler : Callable[[str], None], None
-            Handler for STDERR. It is supposed to be a function with one argument of str.
+            Handler for stderr. It is supposed to be a function with one argument of str.
 
         finalizer : Callable[[subprocess.Popen,...], Any], optional
             Function which finalizes output process handling. Defaults to ``None``.
 
         decode_streams : bool, optional
-            Determines whether to safely decode STDOUT/STDERR streams before pushing their
+            Determines whether to safely decode standard streams before pushing their
             contents to handlers. Should be set to ``False`` if 'universal_newline == True'
             (then streams are in text-mode) or if decoding must happen later. Defaults to ``True``.
 
@@ -1065,7 +1065,7 @@ class OslServerProcess:
         """
         logger.debug("Start to handling optiSLang server process output.")
 
-        # Use 2 "pupm" threads and wait for both to finish.
+        # Use 2 "pump" threads and wait for both to finish.
         if utils.is_iron_python():
 
             def stream_reader(cmdline, name, stream, is_decode, handler):
@@ -1115,9 +1115,9 @@ class OslServerProcess:
 
         pumps = []
         if process.stdout and stdout_handler is not None:
-            pumps.append(("Stdout", process.stdout, stdout_handler))
+            pumps.append(("stdout", process.stdout, stdout_handler))
         if process.stderr and stderr_handler is not None:
-            pumps.append(("Stderr", process.stderr, stderr_handler))
+            pumps.append(("stderr", process.stderr, stderr_handler))
 
         threads = []
 

--- a/tests/test_optislang.py
+++ b/tests/test_optislang.py
@@ -20,11 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from logging import Logger
+
 import pytest
 
 from ansys.optislang.core import Optislang
 from ansys.optislang.core.application import Application
-from ansys.optislang.core.logging import OslCustomAdapter
 from ansys.optislang.core.osl_server import OslServer
 from ansys.optislang.core.project import Project
 
@@ -60,7 +61,7 @@ def test_optislang_properties(optislang: Optislang):
     assert isinstance(application, Application)
 
     logger = optislang.log
-    assert isinstance(logger, OslCustomAdapter)
+    assert isinstance(logger, Logger)
 
     name = optislang.name
     assert isinstance(name, str)


### PR DESCRIPTION
Several changes in the logging module:
- Removal of the logging adapter. The implementation was not type-safe and only added the osl instance name as a Logrecord attribute, which didn't really work.
- Change the general log message format:
  * Put timestamp to the front and use ISO format.
  * Omit current module.
- Removal of session header which is printed on module import. This doesn't always correspond to a session (e.g. in an interactive shell).
- Strip newlines from optiSLang process output.
- Remove redundant `__getitem__` implementation.
- Remove `add_child_logger` method.
- Don't retain logger instances in a separate dict.