### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: ansys/actions/build-wheelhouse@v8
         with:
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ This is the best place to post questions and code.
 
 Installation
 ------------
-The ``ansys-optislang-core`` package supports Python 3.8 through 3.12 on
+The ``ansys-optislang-core`` package supports Python 3.9 through 3.12 on
 Windows and Linux. Three modes of installation are available:
 
 - User installation
@@ -114,12 +114,12 @@ assets and download the wheelhouse corresponding to your setup.
 You can then install PyOptiSLang and all of its dependencies from one single entry point
 that can be shared internally, which eases the security review of the PyOptiSLang package content.
 
-For example, on Linux with Python 3.8, unzip the wheelhouse and install PyOptiSLang with code
+For example, on Linux with Python 3.9, unzip the wheelhouse and install PyOptiSLang with code
 like this:
 
 .. code:: bash
 
-    unzip PyOptiSLang-v0.1.0-wheelhouse-Linux-3.8.zip wheelhouse
+    unzip PyOptiSLang-v0.1.0-wheelhouse-Linux-3.9.zip wheelhouse
     pip install ansys-optislang-core -f wheelhouse --no-index --upgrade --ignore-installed
 
 If you're on Windows with Python 3.9, unzip the wheelhouse to a wheelhouse directory and

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -8,7 +8,7 @@ on the Ansys website.
 ************
 Installation
 ************
-The ``ansys-optislang-core`` package supports Python 3.8 through 3.12 on
+The ``ansys-optislang-core`` package supports Python 3.9 through 3.12 on
 Windows and Linux. Three modes of installation are available:
 
 - User installation
@@ -62,12 +62,12 @@ assets and download the wheelhouse corresponding to your setup.
 You can then install PyOptiSLang and all of its dependencies from one single entry point
 that can be shared internally, which eases the security review of the PyOptiSLang package content.
 
-For example, on Linux with Python 3.8, unzip the wheelhouse and install PyOptiSLang with code
+For example, on Linux with Python 3.9, unzip the wheelhouse and install PyOptiSLang with code
 like this:
 
 .. code:: bash
 
-    unzip PyOptiSLang-v0.1.0-wheelhouse-Linux-3.8.zip wheelhouse
+    unzip PyOptiSLang-v0.1.0-wheelhouse-Linux-3.9.zip wheelhouse
     pip install ansys-optislang-core -f wheelhouse --no-index --upgrade --ignore-installed
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-optislang-core"
 version = "0.8.dev0"
 description = "A Python wrapper for Ansys optiSLang application."
 readme = "README.rst"
-requires-python = ">=3.8,<4"
+requires-python = ">=3.9,<4"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
@@ -23,7 +23,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,{py38,py39,py310,py311,py312}{,-cov}, doc
+    style,{py39,py310,py311,py312}{,-cov}, doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build
@@ -11,7 +11,6 @@ isolated_build_env = build
 passenv = *
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11


### PR DESCRIPTION
Drop support for Python 3.8 after it has reached EOL.