### PR TITLE
Fix issues in integration tests

### DIFF
--- a/tests/tcp/test_nodes_connection.py
+++ b/tests/tcp/test_nodes_connection.py
@@ -28,6 +28,7 @@ import pytest
 
 from ansys.optislang.core import Optislang
 from ansys.optislang.core.nodes import InputSlot, OutputSlot, SlotType
+from ansys.optislang.core.osl_server import OslVersion
 from ansys.optislang.core.slot_types import SlotTypeHint
 from ansys.optislang.core.tcp.nodes import (
     Edge,
@@ -135,6 +136,9 @@ def test_connect_nodes(optislang: Optislang, tmp_path: Path):
 
 def test_disconnect_nodes(optislang: Optislang, tmp_path: Path):
     """Test disconnecting nodes."""
+    if optislang.osl_version < OslVersion(24, 1, 0, 0):
+        pytest.skip(f"Not compatible with {optislang.osl_version_string}")
+
     rs: TcpRootSystemProxy = optislang.project.root_system
     a: TcpNodeProxy = rs.find_nodes_by_name("A")[0]
     b: TcpNodeProxy = rs.find_nodes_by_name("B")[0]

--- a/tests/tcp/test_tcp_managers.py
+++ b/tests/tcp/test_tcp_managers.py
@@ -28,6 +28,7 @@ from ansys.optislang.core import Optislang
 from ansys.optislang.core.io import File
 from ansys.optislang.core.managers import DesignManager
 from ansys.optislang.core.nodes import ParametricSystem
+from ansys.optislang.core.osl_server import OslVersion
 from ansys.optislang.core.project_parametric import (
     ComparisonType,
     ConstraintCriterion,
@@ -388,6 +389,11 @@ def test_get_responses_names(optislang: Optislang):
 # region Designs
 def test_get_design_s(optislang: Optislang, tmp_example_project):
     """Test ``get_design`` and ``get_designs`` method."""
+
+    # NOTE Skipping because tcp query for result design has changed in 24R2
+    if optislang.osl_version < OslVersion(24, 2, 0, 0):
+        pytest.skip(f"Not compatible with {optislang.osl_version_string}")
+
     with Optislang(project_path=tmp_example_project("omdb_files")) as osl:
         project = osl.project
         root_system = project.root_system

--- a/tests/tcp/test_tcp_nodes.py
+++ b/tests/tcp/test_tcp_nodes.py
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from pathlib import Path
-
 import pytest
 
 from ansys.optislang.core import Optislang
@@ -478,42 +476,6 @@ def test_get_omdb_files(optislang: Optislang, tmp_example_project):
     mis_omdb_file = most_inner_sensitivity.get_omdb_files()
     assert len(mis_omdb_file) > 0
     assert isinstance(mis_omdb_file[0], File)
-
-
-def test_save_designs_as(tmp_path: Path, tmp_example_project):
-    """Test `save_designs_as_json` and `save_designs_as_csv` methods."""
-    with Optislang(project_path=tmp_example_project("omdb_files")) as osl:
-        osl.timeout = 60
-        osl.application.project.reset()
-        osl.application.project.start()
-
-        project = osl.project
-        root_system = project.root_system
-
-        __test_save_designs_as_csv(tmp_path, root_system)
-        __test_save_designs_as_json(tmp_path, root_system)
-
-
-def __test_save_designs_as_csv(tmp_path: Path, root_system: TcpRootSystemProxy):
-    """Test `save_designs_as_csv` method."""
-    sensitivity: TcpParametricSystemProxy = root_system.find_nodes_by_name("Sensitivity")[0]
-    s_hids = sensitivity.get_states_ids()
-    csv_file_path = tmp_path / "FirstDesign.csv"
-    csv_file = sensitivity.save_designs_as_csv(s_hids[0], csv_file_path)
-    assert isinstance(csv_file, File)
-    assert csv_file.exists
-
-
-def __test_save_designs_as_json(tmp_path: Path, root_system: TcpRootSystemProxy):
-    """Test `save_designs_as_json` method."""
-    most_inner_sensitivity: TcpParametricSystemProxy = root_system.find_nodes_by_name(
-        "MostInnerSensitivity", 3
-    )[0]
-    mis_hids = most_inner_sensitivity.get_states_ids()
-    json_file_path = tmp_path / "InnerDesign.json"
-    json_file = most_inner_sensitivity.save_designs_as_json(mis_hids[0], json_file_path)
-    assert isinstance(json_file, File)
-    assert json_file.exists
 
 
 # endregion


### PR DESCRIPTION
- Skip some tests for older optiSLang versions.
- Remove tests for deprecated methods.