### PR TITLE
Maint/typing

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           python -m venv venv
           . ./venv/bin/activate
-          python -m pip install mypy .[typing]
+          python -m pip install .[typing]
       - shell: bash
         name: "Run mypy"
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -28,6 +28,27 @@ jobs:
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
+  typing:
+    name: "Type check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+      - shell: bash
+        name: "Setup environment"
+        run: |
+          python -m venv venv
+          . ./venv/bin/activate
+          python -m pip install mypy .[typing]
+      - shell: bash
+        name: "Run mypy"
+        run: |
+          . ./venv/bin/activate
+          python -m mypy src
+
+
   doc-style:
     name: "Doc style check"
     runs-on: ubuntu-latest

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -71,3 +71,15 @@ This way, it's not possible for you to push code that fails the style checks::
   isort....................................................................Passed
   flake8...................................................................Passed
   codespell................................................................Passed
+
+Static type checking
+--------------------
+
+Type-safety is currently assured with workflow job that runs mypy. To run it
+locally, activate the virtual environment and install the required packages::
+
+  python -m pip install ".[typing]"
+ 
+Then run mypy on the source folder::
+
+  python -m mypy src

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -10,3 +10,4 @@ Ansys
 design_flow
 integration_plugins
 THIRDPARTY
+mypy

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-mypy_path = $MYPY_CONFIG_FILE_DIR/src
-explicit_package_bases = True
-exclude = 00_run_script

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ build = [
     "build>=0.8.0",
     "twine>=4.0.1",
 ]
+typing = [
+    "mypy==1.17.0",
+    "types-Deprecated",
+    "types-psutil"
+]
 
 [tool.flit.module]
 name = "ansys.optislang.core"
@@ -94,3 +99,8 @@ markers = [
 [tool.codespell]
 ignore-words = "doc/styles/config/vocabularies/ANSYS/accept.txt"
 skip = "CONTRIBUTORS.md"
+
+[tool.mypy]
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
+explicit_package_bases = true
+exclude = ["00_run_script"]

--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from copy import copy
 import logging
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from ansys.optislang.core import Optislang
@@ -147,16 +147,9 @@ class OslLogger:
         logging.logger
             Logger instance.
         """
-
-        class BaseLogger(logging.Logger):
-            # TODO Added preliminarily to silence type errors
-            std_out_handler: logging.StreamHandler | None
-            file_handler: logging.FileHandler | None
-
-        new_logger = cast(BaseLogger, logging.getLogger(new_logger_name))
-
-        new_logger.std_out_handler = None
-        new_logger.file_handler = None
+        new_logger = logging.getLogger(new_logger_name)
+        new_logger.std_out_handler = None  # type: ignore[attr-defined]
+        new_logger.file_handler = None  # type: ignore[attr-defined]
 
         if level is None:
             level = self.log_level
@@ -164,14 +157,14 @@ class OslLogger:
         new_logger.setLevel(level)
 
         if self.file_handler:
-            new_logger.file_handler = copy(self.file_handler)
-            new_logger.addHandler(new_logger.file_handler)
-            new_logger.file_handler.setLevel(level)
+            new_logger.file_handler = copy(self.file_handler)  # type: ignore[attr-defined]
+            new_logger.addHandler(new_logger.file_handler)  # type: ignore[attr-defined]
+            new_logger.file_handler.setLevel(level)  # type: ignore[attr-defined]
 
         if self.std_out_handler:
-            new_logger.std_out_handler = copy(self.std_out_handler)
-            new_logger.addHandler(new_logger.std_out_handler)
-            new_logger.std_out_handler.setLevel(level)
+            new_logger.std_out_handler = copy(self.std_out_handler)  # type: ignore[attr-defined]
+            new_logger.addHandler(new_logger.std_out_handler)  # type: ignore[attr-defined]
+            new_logger.std_out_handler.setLevel(level)  # type: ignore[attr-defined]
 
         new_logger.propagate = True
         return new_logger

--- a/src/ansys/optislang/core/logging.py
+++ b/src/ansys/optislang/core/logging.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from copy import copy
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, cast
 
 if TYPE_CHECKING:
     from ansys.optislang.core import Optislang
@@ -147,7 +147,14 @@ class OslLogger:
         logging.logger
             Logger instance.
         """
-        new_logger = logging.getLogger(new_logger_name)
+
+        class BaseLogger(logging.Logger):
+            # TODO Added preliminarily to silence type errors
+            std_out_handler: logging.StreamHandler | None
+            file_handler: logging.FileHandler | None
+
+        new_logger = cast(BaseLogger, logging.getLogger(new_logger_name))
+
         new_logger.std_out_handler = None
         new_logger.file_handler = None
 

--- a/src/ansys/optislang/core/managers.py
+++ b/src/ansys/optislang/core/managers.py
@@ -232,7 +232,7 @@ class DesignManager:
         hid: Optional[str] = None,
         include_design_values=True,
         include_non_scalar_design_values=False,
-    ) -> Tuple[Design]:  # pragma: no cover
+    ) -> Tuple[Design, ...]:  # pragma: no cover
         """Get designs for a given state.
 
         Parameters
@@ -329,7 +329,7 @@ class DesignManager:
         status: Optional[DesignStatus] = None,
         pareto_design: Optional[bool] = None,
         feasible: Optional[bool] = None,
-    ) -> Tuple[Design]:  # pragma: no cover
+    ) -> Tuple[Design, ...]:  # pragma: no cover
         """Filter designs by given parameters.
 
         Parameters
@@ -354,7 +354,7 @@ class DesignManager:
 
     @staticmethod
     @abstractmethod
-    def sort_designs_by_hid(designs: Iterable[Design]) -> Tuple[Design]:  # pragma: no cover
+    def sort_designs_by_hid(designs: Iterable[Design]) -> Tuple[Design, ...]:  # pragma: no cover
         """Sort designs by hierarchical id.
 
         Parameters

--- a/src/ansys/optislang/core/node_types.py
+++ b/src/ansys/optislang/core/node_types.py
@@ -1110,7 +1110,7 @@ def get_node_type_from_str(node_id: str) -> NodeType:
         for custom in customs.keys():
             if node_id.startswith(custom):
                 id_ = node_id.replace(custom, "")
-                subtype = customs[custom]  # type: ignore
+                subtype = customs[custom]  # type: ignore[assignment]
                 was_found = True
                 break
         if not was_found:

--- a/src/ansys/optislang/core/nodes.py
+++ b/src/ansys/optislang/core/nodes.py
@@ -1500,7 +1500,7 @@ class ParametricSystem(System):
         pass
 
     @abstractmethod
-    def get_omdb_files(self) -> Tuple[File]:  # pragma: no cover
+    def get_omdb_files(self) -> Tuple[File, ...]:  # pragma: no cover
         """Get paths to omdb files.
 
         Returns

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -953,7 +953,9 @@ class OslServerProcess:
                 "start of the optiSLang process."
             )
 
-        creation_flags = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
+        creation_flags = (
+            subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0  #  type: ignore
+        )
 
         self._logger.debug("Executing process %s", args)
         self.__process = subprocess.Popen(
@@ -1023,7 +1025,7 @@ class OslServerProcess:
 
         return self.__process.poll() is None
 
-    def wait_for_finished(self, timeout: float = None) -> Optional[int]:
+    def wait_for_finished(self, timeout: Optional[float] = None) -> Optional[int]:
         """Wait for the process to finish.
 
         Parameters

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -36,7 +36,7 @@ import psutil
 from ansys.optislang.core import encoding, utils
 
 if utils.is_iron_python():
-    import System  # type: ignore
+    import System  # type: ignore[import-not-found]
 
 
 class ServerNotification(Enum):
@@ -923,10 +923,10 @@ class OslServerProcess:
         start_info.Arguments = " ".join(args)
 
         self.__process = System.Diagnostics.Process()
-        self.__process.StartInfo = start_info  # type: ignore
+        self.__process.StartInfo = start_info  # type: ignore[union-attr]
 
         self._logger.debug("Executing process %s", args)
-        self.__process.Start()  # type: ignore
+        self.__process.Start()  # type: ignore[union-attr]
 
     def __start_in_python(self, args: List[str], env_vars: Dict[str, str]):
         """Start new optiSLang server process with Python interpreter.
@@ -954,7 +954,9 @@ class OslServerProcess:
             )
 
         creation_flags = (
-            subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0  #  type: ignore
+            subprocess.CREATE_NO_WINDOW  #  type: ignore[attr-defined]
+            if sys.platform == "win32"
+            else 0
         )
 
         self._logger.debug("Executing process %s", args)

--- a/src/ansys/optislang/core/project_parametric.py
+++ b/src/ansys/optislang/core/project_parametric.py
@@ -428,7 +428,7 @@ class Criterion:
         """
         self.name = name
         self.expression = expression
-        self.criterion = criterion
+        self.criterion = criterion  # type: ignore[assignment]
 
         if isinstance(type_, str):
             type_ = CriterionType.from_str(type_)
@@ -441,13 +441,16 @@ class Criterion:
             )
 
         if expression_value and isinstance(expression_value_type, CriterionValueType):
-            self.expression_value = (expression_value_type, expression_value)
+            self.expression_value = (
+                expression_value_type,
+                expression_value,
+            )  # type: ignore[assignment]
         else:
-            self.expression_value = expression_value
+            self.expression_value = expression_value  # type: ignore[assignment]
         if value and isinstance(value_type, CriterionValueType):
-            self.value = (value_type, value)
+            self.value = (value_type, value)  # type: ignore[assignment]
         else:
-            self.value = value
+            self.value = value  # type: ignore[assignment]
 
     def __eq__(self, other) -> bool:
         """Compare properties of two instances of the ``Criterion`` class.
@@ -546,7 +549,7 @@ class Criterion:
             expression_value[0], CriterionValueType
         ):
             self.__expression_value = self._parse_str_to_value(
-                expression_value[0], expression_value[1]
+                expression_value[0], expression_value[1]  # type: ignore[arg-type]
             )
             self.__expression_value_type = expression_value[0]
         else:
@@ -599,7 +602,7 @@ class Criterion:
     ) -> None:
         """Set criterion value."""
         if isinstance(value, tuple) and isinstance(value[0], CriterionValueType):
-            self.__value = self._parse_str_to_value(value[0], value[1])
+            self.__value = self._parse_str_to_value(value[0], value[1])  # type: ignore[arg-type]
             self.__value_type = value[0]
         else:
             self.__value = value
@@ -610,8 +613,8 @@ class Criterion:
         """Return type of the criterion value."""
         return self.__value_type
 
-    @staticmethod
-    def from_dict(criterion_dict: dict) -> Criterion:
+    @classmethod
+    def from_dict(cls, criterion_dict: dict) -> Criterion:
         """Create an instance of the ``Criterion`` class from actor properties.
 
         Parameters
@@ -629,9 +632,7 @@ class Criterion:
         TypeError
             Raised when undefined type of criterion is given.
         """
-        criterion_properties = __class__._extract_criterion_properties_from_dict(  # type: ignore
-            criterion_dict
-        )
+        criterion_properties = cls._extract_criterion_properties_from_dict(criterion_dict)
         comparison_type = criterion_properties["criterion"]
 
         if comparison_type == ComparisonType.IGNORE:
@@ -848,7 +849,7 @@ class Criterion:
         # evaluation of second part creates tuple
         # TODO don't use eval
         eval_str = eval(splitted_str[1])
-        matrix_list = []
+        matrix_list = []  # type: ignore[var-annotated]
         for row_index in range(size[0]):
             matrix_list.append([])
             for column_index in range(size[1]):
@@ -886,13 +887,13 @@ class Criterion:
                 if imag == 0:
                     return real
                 else:
-                    return complex(real=real, imag=imag)
+                    return complex(real=real, imag=imag)  # type: ignore[arg-type]
             elif isinstance(value, (int, float)):
                 return value
         elif value_type == CriterionValueType.VECTOR:
-            return Criterion._parse_str_to_vector(value)
+            return Criterion._parse_str_to_vector(value)  # type: ignore[arg-type]
         elif value_type == CriterionValueType.MATRIX:
-            return Criterion._parse_str_to_matrix(value)
+            return Criterion._parse_str_to_matrix(value)  # type: ignore[arg-type]
         elif value_type == CriterionValueType.SIGNAL or value_type == CriterionValueType.XYDATA:
             return (
                 Criterion._parse_str_to_matrix(value[0]),
@@ -916,7 +917,7 @@ class Criterion:
         # TODO don't use eval
         size = eval(size_str)
         if size[0] == 1:
-            splitted_str[1][-2:-2] = ","
+            splitted_str[1][-2:-2] = ","  # type: ignore[index]
         # evaluatiaon of second part creates tuple
         # TODO don't use eval
         eval_str = eval(splitted_str[1])
@@ -944,19 +945,22 @@ class Criterion:
         value_dict = {"kind": value_type.name.lower()}
         if value_type == CriterionValueType.SCALAR:
             if isinstance(value, complex):
+                complex_value = {"imag": value.imag, "real": value.real}
                 value_dict.update(
-                    {value_type.name.lower(): {"imag": value.imag, "real": value.real}}
+                    {value_type.name.lower(): complex_value}  # type: ignore[dict-item]
                 )
             else:
-                value_dict.update({value_type.name.lower(): {"real": value}})
+                value_dict.update(
+                    {value_type.name.lower(): {"real": value}}  # type: ignore[dict-item]
+                )
         elif value_type == CriterionValueType.SIGNAL or value_type == CriterionValueType.XYDATA:
-            value_dict.update({"matrix": value[0], "vector": value[1]})
+            value_dict.update({"matrix": value[0], "vector": value[1]})  # type: ignore[index]
         elif (
             value_type == CriterionValueType.BOOL
             or value_type == CriterionValueType.MATRIX
             or value_type == CriterionValueType.VECTOR
         ):
-            value_dict.update({value_type.name.lower(): value})
+            value_dict.update({value_type.name.lower(): value})  # type: ignore[dict-item]
         return value_dict
 
 
@@ -1018,9 +1022,12 @@ class ConstraintCriterion(Criterion):
         self.__limit_expression = limit_expression
 
         if limit_expression_value and isinstance(limit_expression_value_type, CriterionValueType):
-            self.limit_expression_value = (limit_expression_value_type, limit_expression_value)
+            self.limit_expression_value = (
+                limit_expression_value_type,
+                limit_expression_value,
+            )  # type: ignore[assignment]
         else:
-            self.limit_expression_value = limit_expression_value
+            self.limit_expression_value = limit_expression_value  # type: ignore[assignment]
 
     def __eq__(self, other) -> bool:
         """Compare properties of two instances of the ``ConstraintCriterion`` class.
@@ -1103,7 +1110,9 @@ class ConstraintCriterion(Criterion):
     ) -> None:
         """Set limit value."""
         if isinstance(limit_value, tuple) and isinstance(limit_value[0], CriterionValueType):
-            self.__limit_expression_value = self._parse_str_to_value(limit_value[0], limit_value[1])
+            self.__limit_expression_value = self._parse_str_to_value(
+                limit_value[0], limit_value[1]  # type: ignore[arg-type]
+            )
             self.__limit_expression_value_type = limit_value[0]
         else:
             self.__limit_expression_value = limit_value
@@ -1213,9 +1222,12 @@ class LimitStateCriterion(Criterion):
         self.__limit_expression = limit_expression
 
         if limit_expression_value and isinstance(limit_expression_value_type, CriterionValueType):
-            self.limit_expression_value = (limit_expression_value_type, limit_expression_value)
+            self.limit_expression_value = (
+                limit_expression_value_type,
+                limit_expression_value,
+            )  # type: ignore[assignment]
         else:
-            self.limit_expression_value = limit_expression_value
+            self.limit_expression_value = limit_expression_value  # type: ignore[assignment]
 
     def __eq__(self, other) -> bool:
         """Compare properties of two instances of the ``LimitStateCriterion`` class.
@@ -1298,7 +1310,9 @@ class LimitStateCriterion(Criterion):
     ) -> None:
         """Set limit value."""
         if isinstance(limit_value, tuple) and isinstance(limit_value[0], CriterionValueType):
-            self.__limit_expression_value = self._parse_str_to_value(limit_value[0], limit_value[1])
+            self.__limit_expression_value = self._parse_str_to_value(
+                limit_value[0], limit_value[1]  # type: ignore[arg-type]
+            )
             self.__limit_expression_value_type = limit_value[0]
         else:
             self.__limit_expression_value = limit_value
@@ -1856,8 +1870,8 @@ class Parameter:
         """Type of the parameter."""
         return self.__type
 
-    @staticmethod
-    def from_dict(par_dict: dict) -> Parameter:
+    @classmethod
+    def from_dict(cls, par_dict: dict) -> Parameter:
         """Create an instance of the ``Parameter`` class from optiSLang output.
 
         Parameters
@@ -1875,9 +1889,7 @@ class Parameter:
         TypeError
             Raised when an undefined type of parameter is given.
         """
-        parameter_properties = __class__._extract_parameter_properties_from_dict(  # type: ignore
-            par_dict=par_dict
-        )
+        parameter_properties = cls._extract_parameter_properties_from_dict(par_dict=par_dict)
 
         if parameter_properties["type"] == ParameterType.DEPENDENT:
             return DependentParameter(
@@ -2237,7 +2249,7 @@ class MixedParameter(Parameter):
         """Return deep copy of the instance of ``MixedParameter`` class."""
         return MixedParameter(
             name=self.name,
-            reference_value=self.reference_value,
+            reference_value=self.reference_value,  # type: ignore[arg-type]
             id=self.id,
             const=self.const,
             deterministic_resolution=self.deterministic_resolution,
@@ -2822,7 +2834,7 @@ class StochasticParameter(Parameter):
         """Return deep copy of the stochastic parameter."""
         return StochasticParameter(
             name=self.name,
-            reference_value=self.reference_value,
+            reference_value=self.reference_value,  # type: ignore[arg-type]
             id=self.id,
             const=self.const,
             stochastic_resolution=self.stochastic_resolution,
@@ -3054,9 +3066,12 @@ class Response:
         """
         self.name = name
         if reference_value and isinstance(reference_value_type, ResponseValueType):
-            self.reference_value = (reference_value_type, reference_value)
+            self.reference_value = (
+                reference_value_type,
+                reference_value,
+            )  # type: ignore[assignment]
         else:
-            self.reference_value = reference_value
+            self.reference_value = reference_value  # type: ignore[assignment]
 
     def __eq__(self, other) -> bool:
         """Compare properties of two instances of the ``Response`` class.
@@ -3126,7 +3141,7 @@ class Response:
         """Set response reference value."""
         if isinstance(reference_value, tuple) and isinstance(reference_value[0], ResponseValueType):
             self.__reference_value = self._parse_str_to_value(
-                reference_value[0], reference_value[1]
+                reference_value[0], reference_value[1]  # type: ignore[arg-type]
             )
             self.__reference_value_type = reference_value[0]
         else:
@@ -3185,7 +3200,10 @@ class Response:
             return reference_value
         elif reference_value_type == ResponseValueType.SCALAR:
             if isinstance(reference_value, dict):
-                return complex(real=reference_value.get("real"), imag=reference_value.get("imag"))
+                return complex(
+                    reference_value.get("real"),  # type: ignore[arg-type]
+                    reference_value.get("imag"),  # type: ignore[arg-type]
+                )
             elif isinstance(reference_value, (int, float)):
                 return reference_value
         elif reference_value_type == ResponseValueType.VECTOR:
@@ -3574,15 +3592,17 @@ class Design:
         if isinstance(parameter, Parameter):
             value = parameter.reference_value
         elif isinstance(parameter, DesignVariable):
-            value = parameter.value
+            value = parameter.value  # type: ignore[assignment]
         else:
             raise TypeError(f"Invalid type of parameter: `{type(parameter)}`.")
 
         index = self.__find_name_index(name=parameter.name, type_="parameter")
         if index is not None:
-            self.__parameters[index].value = value
+            self.__parameters[index].value = value  # type: ignore[assignment]
         else:
-            self.__parameters.append(DesignVariable(name=parameter.name, value=value))
+            self.__parameters.append(
+                DesignVariable(name=parameter.name, value=value)  # type: ignore[arg-type]
+            )
 
     def set_parameter_by_name(
         self,
@@ -3625,9 +3645,11 @@ class Design:
             raise TypeError(f"Invalid type of name: `{type(name)}`.")
 
         if index is not None:
-            self.__parameters[index].value = value
+            self.__parameters[index].value = value  # type: ignore[assignment]
         else:
-            self.__parameters.append(DesignVariable(name=name, value=value))
+            self.__parameters.append(
+                DesignVariable(name=name, value=value)  # type: ignore[arg-type]
+            )
 
     def __find_name_index(self, name: str, type_: str) -> Optional[int]:
         """Find the index of a criterion, parameter, response, or variable by name.

--- a/src/ansys/optislang/core/project_parametric.py
+++ b/src/ansys/optislang/core/project_parametric.py
@@ -531,7 +531,7 @@ class Criterion:
         if not isinstance(expression, str):
             raise TypeError(f"Type `str` was expected, but type: `{type(expression)}` was given.")
         self.__expression = expression
-        self.expression_value = None
+        self.expression_value = None  # type: ignore[assignment]
         self.value = None
 
     @property
@@ -1096,7 +1096,7 @@ class ConstraintCriterion(Criterion):
                 f"Type `str` was expected, but type: `{type(limit_expression)}` was given."
             )
         self.__limit_expression = limit_expression
-        self.limit_expression_value = None
+        self.limit_expression_value = None  # type: ignore[assignment]
         self.value = None
 
     @property
@@ -1296,7 +1296,7 @@ class LimitStateCriterion(Criterion):
                 f"Type `str` was expected, but type: `{type(limit_expression)}` was given."
             )
         self.__limit_expression = limit_expression
-        self.limit_expression_value = None
+        self.limit_expression_value = None  # type: ignore[assignment]
         self.value = None
 
     @property
@@ -2268,7 +2268,7 @@ class MixedParameter(Parameter):
         """Reference value of the parameter."""
         return self.__reference_value
 
-    @reference_value.setter
+    @reference_value.setter  # type: ignore[override]
     def reference_value(
         self,
         reference_value: float,
@@ -2851,7 +2851,7 @@ class StochasticParameter(Parameter):
         """Reference value of the parameter."""
         return self.__reference_value
 
-    @reference_value.setter
+    @reference_value.setter  # type: ignore[override]
     def reference_value(
         self,
         reference_value: float,

--- a/src/ansys/optislang/core/tcp/managers.py
+++ b/src/ansys/optislang/core/tcp/managers.py
@@ -391,8 +391,9 @@ class TcpDesignManagerProxy(DesignManager):
             Tuple of designs for a given state.
         """
         design_classes = []
+        assert hid is not None
         status_info = self._get_status_info(
-            hid=hid,  # type: ignore[arg-type]
+            hid=hid,
             include_designs=True,
             include_design_values=include_design_values,
             include_non_scalar_design_values=include_design_values

--- a/src/ansys/optislang/core/tcp/managers.py
+++ b/src/ansys/optislang/core/tcp/managers.py
@@ -301,10 +301,10 @@ class TcpDesignManagerProxy(DesignManager):
     def _get_status_info(
         self,
         hid: str,
-        include_designs: bool = True,
-        include_design_values: Optional[bool] = True,
-        include_non_scalar_design_values: Optional[bool] = False,
-        include_algorithm_info: Optional[bool] = False,
+        include_designs: bool,
+        include_design_values: bool,
+        include_non_scalar_design_values: bool,
+        include_algorithm_info: bool,
     ) -> Dict:
         """Get status info about actor defined by actor uid and state hid.
 
@@ -312,14 +312,14 @@ class TcpDesignManagerProxy(DesignManager):
         ----------
         hid : str
             State/Design hierarchical id.
-        include_designs : bool, optional
-           Include (result) designs in status info response. By default ``True``.
-        include_design_values : Optional[bool], optional
-            Include values in (result) designs. By default ``True``.
-        include_non_scalar_design_values : Optional[bool], optional
-            Include non scalar values in (result) designs. By default ``False``.
-        include_algorithm_info : Optional[bool], optional
-            Include algorithm result info in status info response, by default ``False``.
+        include_designs : bool
+           Include (result) designs in status info response.
+        include_design_values : bool
+            Include values in (result) designs.
+        include_non_scalar_design_values : bool
+            Include non scalar values in (result) designs.
+        include_algorithm_info : bool
+            Include algorithm result info in status info response.
 
         Returns
         -------

--- a/src/ansys/optislang/core/tcp/managers.py
+++ b/src/ansys/optislang/core/tcp/managers.py
@@ -104,7 +104,7 @@ class TcpCriteriaManagerProxy(CriteriaManager):
                 limit=(
                     criterion.limit_expression
                     if isinstance(criterion, (ConstraintCriterion, LimitStateCriterion))
-                    else None
+                    else ""
                 ),
             )
 

--- a/src/ansys/optislang/core/tcp/managers.py
+++ b/src/ansys/optislang/core/tcp/managers.py
@@ -373,7 +373,7 @@ class TcpDesignManagerProxy(DesignManager):
         hid: Optional[str] = None,
         include_design_values=True,
         include_non_scalar_design_values=False,
-    ) -> Tuple[Design]:
+    ) -> Tuple[Design, ...]:
         """Get designs for a given state.
 
         Parameters
@@ -392,7 +392,7 @@ class TcpDesignManagerProxy(DesignManager):
         """
         design_classes = []
         status_info = self._get_status_info(
-            hid=hid,
+            hid=hid,  # type: ignore[arg-type]
             include_designs=True,
             include_design_values=include_design_values,
             include_non_scalar_design_values=include_design_values
@@ -604,7 +604,7 @@ class TcpDesignManagerProxy(DesignManager):
         status: Optional[DesignStatus] = None,
         pareto_design: Optional[bool] = None,
         feasible: Optional[bool] = None,
-    ) -> Tuple[Design]:
+    ) -> Tuple[Design, ...]:
         """Filter designs by given parameters.
 
         Parameters
@@ -635,10 +635,10 @@ class TcpDesignManagerProxy(DesignManager):
             ]
             return all(conditions)
 
-        return tuple([design for design in filter(filter_condition, designs)])
+        return tuple(design for design in filter(filter_condition, designs))
 
     @staticmethod
-    def sort_designs_by_hid(designs: Iterable[Design]) -> Tuple[Design]:
+    def sort_designs_by_hid(designs: Iterable[Design]) -> Tuple[Design, ...]:
         """Sort designs by hierarchical id.
 
         Parameters
@@ -652,7 +652,10 @@ class TcpDesignManagerProxy(DesignManager):
             Tuple of sorted designs.
         """
         sorted_designs = sorted(
-            designs, key=lambda design: [int(part) for part in design.id.split(".")]
+            designs,
+            key=lambda design: [
+                int(part) for part in design.id.split(".")  # type: ignore[union-attr]
+            ],
         )
         return tuple(sorted_designs)
 

--- a/src/ansys/optislang/core/tcp/nodes.py
+++ b/src/ansys/optislang/core/tcp/nodes.py
@@ -2069,7 +2069,7 @@ class TcpSystemProxy(TcpNodeProxy, System):
         return tuple(children_dicts_list)
 
     @staticmethod
-    def _find_subtree(tree: dict, uid: str, nodes_tree: List[dict]) -> dict:
+    def _find_subtree(tree: dict, uid: str, nodes_tree: List[dict]) -> List[dict]:
         """Find the subtree with a root node matching a specified unique ID.
 
         Parameters
@@ -2275,7 +2275,7 @@ class TcpParametricSystemProxy(TcpSystemProxy, ParametricSystem):
             self._get_slots(type_=SlotType.INNER_OUTPUT, name=name),
         )
 
-    def get_omdb_files(self) -> Tuple[File]:
+    def get_omdb_files(self) -> Tuple[File, ...]:
         """Get paths to omdb files.
 
         This method is supported only when the client runs on the same file
@@ -2544,8 +2544,8 @@ class TcpParametricSystemProxy(TcpSystemProxy, ParametricSystem):
         """
         statuses_info = self._get_status_info()
         if not statuses_info:
-            return {}
-        designs = {}
+            return OrderedDict()
+        designs = OrderedDict()
         # TODO: sort by hid? -> delete / use OrderedDict
         for status_info in statuses_info:
             designs[status_info["hid"]] = status_info["designs"]
@@ -2609,7 +2609,7 @@ class TcpParametricSystemProxy(TcpSystemProxy, ParametricSystem):
         return sorted(unsorted_list, key=sort_key)
 
     @staticmethod
-    def __sort_dict_by_key_hid(unsorted_dict: dict, sort_by_position: int) -> dict:
+    def __sort_dict_by_key_hid(unsorted_dict: dict, sort_by_position: int) -> OrderedDict:
         sort_key = lambda item: int(item[0].split(".")[sort_by_position])
         return OrderedDict(sorted(unsorted_dict.items(), key=sort_key))
 
@@ -2732,7 +2732,9 @@ class TcpRootSystemProxy(TcpParametricSystemProxy, RootSystem):
         for parameter in design.parameters:
             evaluate_dict[parameter.name] = parameter.value
 
-        output_dict = self._osl_server.evaluate_design(evaluate_dict=evaluate_dict)
+        output_dict = self._osl_server.evaluate_design(
+            evaluate_dict=evaluate_dict  # type: ignore[arg-type]
+        )
         return self.__create_evaluated_design(
             input_design=design, evaluate_dict=evaluate_dict, results=output_dict[0]
         )
@@ -2789,10 +2791,10 @@ class TcpRootSystemProxy(TcpParametricSystemProxy, RootSystem):
         sorted_criteria = self.__categorize_criteria(criteria=criteria)
         return Design(
             parameters=parameters,
-            constraints=sorted_criteria.get("constraints", []),
-            limit_states=sorted_criteria.get("limit_states", []),
-            objectives=sorted_criteria.get("objectives", []),
-            variables=sorted_criteria.get("variables", []),
+            constraints=sorted_criteria.get("constraints", []),  # type: ignore[arg-type]
+            limit_states=sorted_criteria.get("limit_states", []),  # type: ignore[arg-type]
+            objectives=sorted_criteria.get("objectives", []),  # type: ignore[arg-type]
+            variables=sorted_criteria.get("variables", []),  # type: ignore[arg-type]
             responses=responses,
         )
 
@@ -2978,10 +2980,10 @@ class TcpRootSystemProxy(TcpParametricSystemProxy, RootSystem):
             else:
                 raise TypeError(f"Invalid type of criterion: `{type(criterion)}`.")
         return {
-            "constraints": constraints,
-            "limit_states": limit_states,
-            "objectives": objectives,
-            "variables": variables,
+            "constraints": constraints,  # type: ignore[dict-item]
+            "limit_states": limit_states,  # type: ignore[dict-item]
+            "objectives": objectives,  # type: ignore[dict-item]
+            "variables": variables,  # type: ignore[dict-item]
         }
 
     @staticmethod
@@ -3011,7 +3013,7 @@ class TcpRootSystemProxy(TcpParametricSystemProxy, RootSystem):
             output_value = processed["result_design"]["parameter_values"][index]
             if input_value and input_value != output_value:
                 differences.append((parameter_name, input_value, output_value))
-        return tuple(differences)
+        return tuple(differences)  # type: ignore[return-value]
 
     @staticmethod
     def __get_sorted_difference_of_sets(
@@ -3353,7 +3355,9 @@ class TcpInputSlotProxy(TcpSlotProxy, InputSlot):
             type_hint=type_hint,
         )
 
-    def connect_from(self, from_slot: TcpSlotProxy, skip_rename_slot: bool = False) -> Edge:
+    def connect_from(
+        self, from_slot: TcpSlotProxy, skip_rename_slot: bool = False  # type: ignore[override]
+    ) -> Edge:
         """Connect slot from another slot.
 
         Parameters
@@ -3393,7 +3397,9 @@ class TcpInputSlotProxy(TcpSlotProxy, InputSlot):
             self._osl_server.run_python_script(script=python_script)
         return Edge(from_slot=from_slot, to_slot=self)
 
-    def disconnect(self, sending_slot: Optional[TcpSlotProxy] = None) -> None:
+    def disconnect(
+        self, sending_slot: Optional[TcpSlotProxy] = None  # type: ignore[override]
+    ) -> None:
         """Remove a specific or all connections for the current slot.
 
         Parameters
@@ -3465,7 +3471,9 @@ class TcpOutputSlotProxy(TcpSlotProxy, OutputSlot):
             type_hint=type_hint,
         )
 
-    def connect_to(self, to_slot: TcpSlotProxy, skip_rename_slot: bool = False) -> Edge:
+    def connect_to(
+        self, to_slot: TcpSlotProxy, skip_rename_slot: bool = False  # type: ignore[override]
+    ) -> Edge:
         """Connect slot to another slot.
 
         Parameters
@@ -3505,7 +3513,9 @@ class TcpOutputSlotProxy(TcpSlotProxy, OutputSlot):
             self._osl_server.run_python_script(script=python_script)
         return Edge(from_slot=self, to_slot=to_slot)
 
-    def disconnect(self, receiving_slot: Optional[TcpSlotProxy] = None) -> None:
+    def disconnect(
+        self, receiving_slot: Optional[TcpSlotProxy] = None  # type: ignore[override]
+    ) -> None:
         """Remove a specific or all connections for the current slot.
 
         Parameters
@@ -3577,7 +3587,9 @@ class TcpInnerInputSlotProxy(TcpSlotProxy, InnerInputSlot):
             type_hint=type_hint,
         )
 
-    def connect_from(self, from_slot: TcpSlotProxy, skip_rename_slot: bool = False) -> Edge:
+    def connect_from(
+        self, from_slot: TcpSlotProxy, skip_rename_slot: bool = False  # type: ignore[override]
+    ) -> Edge:
         """Connect slot from another slot.
 
         Parameters
@@ -3617,7 +3629,9 @@ class TcpInnerInputSlotProxy(TcpSlotProxy, InnerInputSlot):
             self._osl_server.run_python_script(script=python_script)
         return Edge(from_slot=from_slot, to_slot=self)
 
-    def disconnect(self, sending_slot: Optional[TcpSlotProxy] = None) -> None:
+    def disconnect(
+        self, sending_slot: Optional[TcpSlotProxy] = None  # type: ignore[override]
+    ) -> None:
         """Remove a specific or all connections for the current slot.
 
         Parameters
@@ -3689,7 +3703,9 @@ class TcpInnerOutputSlotProxy(TcpSlotProxy, InnerOutputSlot):
             type_hint=type_hint,
         )
 
-    def connect_to(self, to_slot: TcpSlotProxy, skip_rename_slot: bool = False) -> Edge:
+    def connect_to(
+        self, to_slot: TcpSlotProxy, skip_rename_slot: bool = False  # type: ignore[override]
+    ) -> Edge:
         """Connect slot to another slot.
 
         Parameters
@@ -3729,7 +3745,9 @@ class TcpInnerOutputSlotProxy(TcpSlotProxy, InnerOutputSlot):
             self._osl_server.run_python_script(script=python_script)
         return Edge(from_slot=self, to_slot=to_slot)
 
-    def disconnect(self, receiving_slot: Optional[TcpSlotProxy] = None) -> None:
+    def disconnect(
+        self, receiving_slot: Optional[TcpSlotProxy] = None  # type: ignore[override]
+    ) -> None:
         """Remove a specific or all connections for the current slot.
 
         Parameters

--- a/src/ansys/optislang/core/tcp/osl_server.py
+++ b/src/ansys/optislang/core/tcp/osl_server.py
@@ -980,8 +980,9 @@ class TcpOslListener:
         while True:
             client = None
             try:
-                self.__listener_socket.settimeout(timeout)  # type: ignore[union-attr]
-                clientsocket, address = self.__listener_socket.accept()  # type: ignore[union-attr]
+                assert self.__listener_socket is not None
+                self.__listener_socket.settimeout(timeout)
+                clientsocket, address = self.__listener_socket.accept()
                 client = TcpClient(clientsocket)
                 message = client.receive_msg(timeout)
                 data_dict = json.loads(message)
@@ -1266,7 +1267,7 @@ class TcpOslServer(OslServer):
             self.__shutdown_on_finished = shutdown_on_finished
             self._start_local(ini_timeout, shutdown_on_finished)
         else:
-            self.__shutdown_on_finished = None  # type: ignore[assignment]
+            self.__shutdown_on_finished = False
             listener = self.__create_listener(
                 timeout=None,  # type:ignore[arg-type]
                 name="Main",
@@ -1419,13 +1420,15 @@ class TcpOslServer(OslServer):
             Raised when the timeout float value expires.
         """
         current_func_name = self.add_criterion.__name__
+
+        assert limit is not None
         self.send_command(
             command=commands.add_criterion(
                 actor_uid=uid,
                 criterion_type=criterion_type,
                 expression=expression,
                 name=name,
-                limit=limit,  # type: ignore[arg-type]
+                limit=limit,
                 password=self.__password,
             ),
             timeout=self.timeouts_register.get_value(current_func_name),
@@ -1566,7 +1569,7 @@ class TcpOslServer(OslServer):
             Raised when the timeout float value expires.
         """
         current_func_name = self.create_node.__name__
-        output: List[dict] = self.send_command(  # type: ignore[assignment]
+        output = self.send_command(
             commands.create_node(
                 type_=type_,
                 name=name,
@@ -3150,7 +3153,7 @@ class TcpOslServer(OslServer):
             ":py:class:`Project <ansys.optislang.core.project.Project>`."
         ),
     )
-    def get_working_dir(self) -> Path:
+    def get_working_dir(self) -> Optional[Path]:
         """Get path to the optiSLang project working directory.
 
         Returns
@@ -3170,7 +3173,7 @@ class TcpOslServer(OslServer):
         """
         project_info = self.get_basic_project_info()
         if len(project_info.get("projects", [])) == 0:
-            return None  # type: ignore[return-value]
+            return None
         return Path(project_info.get("projects", [{}])[0].get("working_dir", None))
 
     def load(self, uid: str, args: Optional[Dict[str, Any]] = None) -> None:
@@ -4056,7 +4059,8 @@ class TcpOslServer(OslServer):
 
         response_str = ""
 
-        for request_attempt in range(1, max_request_attempts + 1):  # type: ignore[operator]
+        assert isinstance(max_request_attempts, int)
+        for request_attempt in range(1, max_request_attempts + 1):
             start_time = time.time()
             try:
                 client.connect(
@@ -4959,9 +4963,10 @@ class TcpOslServer(OslServer):
                             self._logger.debug(
                                 "Refreshing registration for listener: %s", listener.uid
                             )
+                            assert listener.uid is not None
                             self.send_command(
                                 commands.refresh_listener_registration(
-                                    uid=listener.uid,  # type: ignore[arg-type]
+                                    uid=listener.uid,
                                     password=self.__password,
                                 ),
                                 timeout=self.timeouts_register.get_value(current_func_name),

--- a/src/ansys/optislang/core/tcp/osl_server.py
+++ b/src/ansys/optislang/core/tcp/osl_server.py
@@ -1264,10 +1264,8 @@ class TcpOslServer(OslServer):
 
         if self.__host is None or self.__port is None:
             self.__host = self._LOCALHOST
-            self.__shutdown_on_finished = shutdown_on_finished
             self._start_local(ini_timeout, shutdown_on_finished)
         else:
-            self.__shutdown_on_finished = False
             listener = self.__create_listener(
                 timeout=None,  # type:ignore[arg-type]
                 name="Main",

--- a/src/ansys/optislang/core/tcp/osl_server.py
+++ b/src/ansys/optislang/core/tcp/osl_server.py
@@ -824,6 +824,8 @@ class TcpOslListener:
     @property
     def port(self) -> int:
         """Port number associated with self.__listener_socket."""
+        if self.__listener_socket is None:
+            raise ConnectionNotEstablishedError("Socket not set.")
         return self.__listener_socket.getsockname()[1]
 
     @property
@@ -978,8 +980,8 @@ class TcpOslListener:
         while True:
             client = None
             try:
-                self.__listener_socket.settimeout(timeout)
-                clientsocket, address = self.__listener_socket.accept()
+                self.__listener_socket.settimeout(timeout)  # type: ignore[union-attr]
+                clientsocket, address = self.__listener_socket.accept()  # type: ignore[union-attr]
                 client = TcpClient(clientsocket)
                 message = client.receive_msg(timeout)
                 data_dict = json.loads(message)
@@ -1264,9 +1266,9 @@ class TcpOslServer(OslServer):
             self.__shutdown_on_finished = shutdown_on_finished
             self._start_local(ini_timeout, shutdown_on_finished)
         else:
-            self.__shutdown_on_finished = None
+            self.__shutdown_on_finished = None  # type: ignore[assignment]
             listener = self.__create_listener(
-                timeout=None,
+                timeout=None,  # type:ignore[arg-type]
                 name="Main",
                 uid=self.__listener_id,
                 notifications=[
@@ -1285,7 +1287,7 @@ class TcpOslServer(OslServer):
             listener.uid = self.__register_listener(
                 host_addresses=listener.host_addresses,
                 port=listener.port,
-                **register_listener_options,
+                **register_listener_options,  # type: ignore[arg-type]
             )
             listener.refresh_listener_registration = True
             self.__listeners["main_listener"] = listener
@@ -1423,7 +1425,7 @@ class TcpOslServer(OslServer):
                 criterion_type=criterion_type,
                 expression=expression,
                 name=name,
-                limit=limit,
+                limit=limit,  # type: ignore[arg-type]
                 password=self.__password,
             ),
             timeout=self.timeouts_register.get_value(current_func_name),
@@ -1564,7 +1566,7 @@ class TcpOslServer(OslServer):
             Raised when the timeout float value expires.
         """
         current_func_name = self.create_node.__name__
-        output: List[dict] = self.send_command(
+        output: List[dict] = self.send_command(  # type: ignore[assignment]
             commands.create_node(
                 type_=type_,
                 name=name,
@@ -1729,7 +1731,7 @@ class TcpOslServer(OslServer):
             Raised when the timeout float value expires.
         """
         current_func_name = self.evaluate_design.__name__
-        return self.send_command(
+        return self.send_command(  # type: ignore[return-value]
             command=commands.evaluate_design(evaluate_dict, self.__password),
             timeout=self.timeouts_register.get_value(current_func_name),
             max_request_attempts=self.max_request_attempts_register.get_value(current_func_name),
@@ -3168,7 +3170,7 @@ class TcpOslServer(OslServer):
         """
         project_info = self.get_basic_project_info()
         if len(project_info.get("projects", [])) == 0:
-            return None
+            return None  # type: ignore[return-value]
         return Path(project_info.get("projects", [{}])[0].get("working_dir", None))
 
     def load(self, uid: str, args: Optional[Dict[str, Any]] = None) -> None:
@@ -3852,7 +3854,11 @@ class TcpOslServer(OslServer):
         """
         current_func_name = self.run_python_script.__name__
         responses = self.send_command(
-            command=commands.run_python_script(script, args, self.__password),
+            command=commands.run_python_script(
+                script,
+                args,  # type: ignore[arg-type]
+                self.__password,
+            ),
             timeout=self.timeouts_register.get_value(current_func_name),
             max_request_attempts=self.max_request_attempts_register.get_value(current_func_name),
         )
@@ -4050,7 +4056,7 @@ class TcpOslServer(OslServer):
 
         response_str = ""
 
-        for request_attempt in range(1, max_request_attempts + 1):
+        for request_attempt in range(1, max_request_attempts + 1):  # type: ignore[operator]
             start_time = time.time()
             try:
                 client.connect(
@@ -4565,7 +4571,7 @@ class TcpOslServer(OslServer):
 
         listener = self.__create_listener(
             uid=self.__listener_id if self.__listener_id else str(uuid.uuid4()),
-            timeout=None,
+            timeout=None,  # type: ignore[arg-type]
             name="Main",
             notifications=[
                 ServerNotification.SERVER_UP,
@@ -4737,7 +4743,7 @@ class TcpOslServer(OslServer):
             Raised when the timeout float value expires.
         """
         exec_started_listener = self.__create_listener(
-            timeout=timeout,
+            timeout=timeout,  # type: ignore[arg-type]
             name="ExecStarted",
             notifications=[
                 ServerNotification.PROCESSING_STARTED,
@@ -4757,7 +4763,7 @@ class TcpOslServer(OslServer):
         exec_started_listener.uid = self.__register_listener(
             host_addresses=exec_started_listener.host_addresses,
             port=exec_started_listener.port,
-            **register_listener_options,
+            **register_listener_options,  # type: ignore[arg-type]
         )
         exec_started_listener.refresh_listener_registration = True
         self.__listeners["exec_started_listener"] = exec_started_listener
@@ -4784,7 +4790,7 @@ class TcpOslServer(OslServer):
             Raised when the timeout float value expires.
         """
         exec_finished_listener = self.__create_listener(
-            timeout=timeout,
+            timeout=timeout,  # type: ignore[arg-type]
             name="ExecFinished",
             notifications=[
                 ServerNotification.EXECUTION_FINISHED,
@@ -4804,7 +4810,7 @@ class TcpOslServer(OslServer):
         exec_finished_listener.uid = self.__register_listener(
             host_addresses=exec_finished_listener.host_addresses,
             port=exec_finished_listener.port,
-            **register_listener_options,
+            **register_listener_options,  # type: ignore[arg-type]
         )
         exec_finished_listener.refresh_listener_registration = True
         self.__listeners["exec_finished_listener"] = exec_finished_listener
@@ -4955,7 +4961,8 @@ class TcpOslServer(OslServer):
                             )
                             self.send_command(
                                 commands.refresh_listener_registration(
-                                    uid=listener.uid, password=self.__password
+                                    uid=listener.uid,  # type: ignore[arg-type]
+                                    password=self.__password,
                                 ),
                                 timeout=self.timeouts_register.get_value(current_func_name),
                                 max_request_attempts=self.max_request_attempts_register.get_value(
@@ -4984,7 +4991,7 @@ class TcpOslServer(OslServer):
                                     listener.uid = self.__register_listener(
                                         host_addresses=listener.host_addresses,
                                         port=listener.port,
-                                        **register_listener_options,
+                                        **register_listener_options,  # type: ignore[arg-type]
                                     )
                                 except Exception as e:
                                     self._logger.debug(

--- a/src/ansys/optislang/core/tcp/osl_server.py
+++ b/src/ansys/optislang/core/tcp/osl_server.py
@@ -1397,7 +1397,7 @@ class TcpOslServer(OslServer):
         return self.__timeouts_register
 
     def add_criterion(
-        self, uid: str, criterion_type: str, expression: str, name: str, limit: Optional[str] = None
+        self, uid: str, criterion_type: str, expression: str, name: str, limit: str = ""
     ) -> None:
         """Create criterion for the system.
 
@@ -1411,8 +1411,8 @@ class TcpOslServer(OslServer):
             Expression to be evaluated.
         name: str
             Criterion name.
-        limit: Optional[str], optional
-            Limit expression to be evaluated.
+        limit: str
+            Limit expression to be evaluated. Empty string by default.
 
         Raises
         ------
@@ -1421,7 +1421,6 @@ class TcpOslServer(OslServer):
         """
         current_func_name = self.add_criterion.__name__
 
-        assert limit is not None
         self.send_command(
             command=commands.add_criterion(
                 actor_uid=uid,
@@ -3830,7 +3829,7 @@ class TcpOslServer(OslServer):
     def run_python_script(
         self,
         script: str,
-        args: Union[Sequence[object], None] = None,
+        args: Optional[Sequence[object]] = None,
     ) -> Tuple[str, str]:
         """Load a Python script in a project context and execute it.
 

--- a/src/ansys/optislang/core/utils.py
+++ b/src/ansys/optislang/core/utils.py
@@ -467,7 +467,8 @@ def get_localhost_addresses() -> List[str]:
         List of addresses of the localhost machine.
     """
     return [
-        i[4][0] for i in socket.getaddrinfo(socket.gethostname(), None, type=socket.SOCK_STREAM)
+        str(i[4][0])
+        for i in socket.getaddrinfo(socket.gethostname(), None, type=socket.SOCK_STREAM)
     ]
 
 


### PR DESCRIPTION
In an attempt to address the remaining typing errors it turned out that most of them can't be fixed without getting deep into the business logic. At the same time we want to assure that no new errors are introduced. With this PR I propose to

- Add ignore-comments or assertions to the code lines in question
- Add a job that runs mypy in the PR workflow and prevents the introduction of new errors

It's a tradeoff because it gives the impression of type-safety despite the presence of arbitrary ignore-comments. But I believe it's preferable to adding annotations without actually checking them.

Regarding the workflow: The ideal solution would be to use a pre-commit hook and the already present "Code style" job. Due to some quirky behavior of mypy when run as a hook I decided to go with a separate job for now.