### PR TITLE
ci: do not avoid checking lincenses

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -73,7 +73,6 @@ jobs:
           library-name: ${{ env.PACKAGE_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-          check-licenses: false
 
   tests:
     name: "Test ${{ matrix.os }} using Python ${{ matrix.python-version }}"


### PR DESCRIPTION
If there is a specific reason so not check a license please let us know in this PR. Otherwise this should be enabled as soon as possible.