### PR TITLE
MAINT: Make listening on local host (IPV4) default when starting an oSL server

### DIFF
--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -84,8 +84,14 @@ class Optislang:
 
         ..note:: Cannot be used in combination with batch mode.
 
-    port_range : Tuple[int, int], optional
-        Defines the port range for optiSLang server. Defaults to ``None``.
+    server_address : Optional[str], optional
+        In case an optiSLang server is to be started, this defines the address
+        of the optiSLang server. If not specified, optiSLang will be listening on
+        local host only. Defaults to ``None``.
+    port_range : Optional[Tuple[int, int]], optional
+        In case an optiSLang server is to be started, this restricts the port range
+        for the optiSLang server. If not specified, optiSLang will be allowed to
+        listen on any port. Defaults to ``None``.
     no_run : Optional[bool], optional
         Determines whether not to run the specified project when started in batch mode.
         Defaults to ``None``.
@@ -222,6 +228,7 @@ class Optislang:
         project_path: Optional[Union[str, Path]] = None,
         batch: bool = True,
         service: bool = False,
+        server_address: Optional[str] = None,
         port_range: Optional[Tuple[int, int]] = None,
         no_run: Optional[bool] = None,
         no_save: bool = False,
@@ -254,6 +261,7 @@ class Optislang:
         self.__project_path = Path(project_path) if project_path is not None else None
         self.__batch = batch
         self.__service = service
+        self.__server_address = server_address
         self.__port_range = port_range
         self.__no_run = no_run
         self.__no_save = no_save
@@ -317,6 +325,7 @@ class Optislang:
                 shutdown_on_finished=self.__shutdown_on_finished,
                 batch=self.__batch,
                 service=self.__service,
+                server_address=self.__server_address,
                 port_range=self.__port_range,
                 no_run=self.__no_run,
                 force=self.__force,

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -86,8 +86,12 @@ class OslServerProcess:
 
         ..note:: Cannot be used in combination with batch mode.
 
-    port_range : Tuple[int, int], optional
-        Defines the port range for optiSLang server. Defaults to ``None``.
+    server_address : Optional[str], optional
+        This defines the address of the optiSLang server. If not specified, optiSLang will be
+        listening on local host only. Defaults to ``None``.
+    port_range : Optional[Tuple[int, int]], optional
+        This restricts the port range for the optiSLang server. If not specified, optiSLang
+        will be allowed to listen on any port. Defaults to ``None``.
     password : Optional[str], optional
         The server password. Use when communication with the server requires the request
         to contain a password entry. Defaults to ``None``.
@@ -218,6 +222,7 @@ class OslServerProcess:
     """
 
     DEFAULT_PROJECT_FILE = "project.opf"
+    _LOCALHOST = "127.0.0.1"
 
     def __init__(
         self,
@@ -225,6 +230,7 @@ class OslServerProcess:
         project_path: Optional[Union[str, Path]] = None,
         batch: bool = True,
         service: bool = False,
+        server_address: Optional[str] = None,
         port_range: Optional[Tuple[int, int]] = None,
         password: Optional[str] = None,
         no_run: Optional[bool] = None,
@@ -297,6 +303,7 @@ class OslServerProcess:
         self.__dump_project_state = validated_path(dump_project_state)
         self.__opx_project_definition_file = validated_path(opx_project_definition_file)
 
+        self.__server_address = server_address
         self.__port_range = port_range
         self.__password = password
         self.__no_run = no_run
@@ -355,8 +362,19 @@ class OslServerProcess:
         return self.__batch
 
     @property
+    def server_address(self) -> Optional[str]:
+        """Server address of the optiSLang server.
+
+        Returns
+        -------
+        Optional[str]
+            Server address, if defined; ``None`` otherwise.
+        """
+        return self.__server_address
+
+    @property
     def port_range(self) -> Optional[Tuple[int, int]]:
-        """Port range for optiSLang server execution.
+        """Port range for the optiSLang server.
 
         Returns
         -------
@@ -776,6 +794,10 @@ class OslServerProcess:
                 args.append(f"--enable-tcp-server={self.__port_range[0]}-{self.__port_range[1]}")
             else:
                 args.append("--enable-tcp-server")
+            if self.__server_address is not None:
+                args.append(f"--server-address={self.__server_address}")
+            else:
+                args.append(f"--server-address={self._LOCALHOST}")  # Default to localhost
 
         if self.__password is not None:
             # Submits the server password. Use when communication with the server requires

--- a/src/ansys/optislang/core/tcp/osl_server.py
+++ b/src/ansys/optislang/core/tcp/osl_server.py
@@ -1037,8 +1037,14 @@ class TcpOslServer(OslServer):
 
         ..note:: Cannot be used in combination with batch mode.
 
+    server_address : Optional[str], optional
+        In case an optiSLang server is to be started, this defines the address
+        of the optiSLang server. If not specified, optiSLang will be listening on
+        local host only. Defaults to ``None``.
     port_range : Optional[Tuple[int, int]], optional
-        Defines the port range for optiSLang server. Defaults to ``None``.
+        In case an optiSLang server is to be started, this restricts the port range
+        for the optiSLang server. If not specified, optiSLang will be allowed to
+        listen on any port. Defaults to ``None``.
     no_run : Optional[bool], optional
         Determines whether not to run the specified project when started in batch mode.
         Defaults to ``None``.
@@ -1185,6 +1191,7 @@ class TcpOslServer(OslServer):
         project_path: Optional[Union[str, Path]] = None,
         batch: bool = True,
         service: bool = False,
+        server_address: Optional[str] = None,
         port_range: Optional[Tuple[int, int]] = None,
         no_run: Optional[bool] = None,
         no_save: bool = False,
@@ -1221,6 +1228,7 @@ class TcpOslServer(OslServer):
         self.__project_path = Path(project_path) if project_path is not None else None
         self.__batch = batch
         self.__service = service
+        self.__server_address = server_address
         self.__port_range = port_range
         self.__no_run = no_run
         self.__no_save = no_save
@@ -1260,7 +1268,7 @@ class TcpOslServer(OslServer):
         atexit.register(self.dispose)
 
         if self.__host is None or self.__port is None:
-            self.__host = self._LOCALHOST
+            self.__host = self.__server_address if self.__server_address else self._LOCALHOST
             self.__shutdown_on_finished = shutdown_on_finished
             self._start_local(ini_timeout, shutdown_on_finished)
         else:
@@ -4600,6 +4608,7 @@ class TcpOslServer(OslServer):
                 logger=self._logger,
                 batch=self.__batch,
                 service=self.__service,
+                server_address=self.__server_address,
                 port_range=self.__port_range,
                 no_run=self.__no_run,
                 force=self.__force,


### PR DESCRIPTION
- [x] Make listening on local host (IPV4) default when starting an oSL server 
- [x] Add argument to explicitly specify for the oSL server where to listen