### PR TITLE
Pin dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "psutil==7.1.3",
     "Deprecated==1.3.1",
-    "pywin32>=306; sys_platform == 'win32'",
+    "pywin32==311; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In these days it can't hurt to lock the runtime requirements and let dependabot handle the updates.

Note that `Deprecated` still has a single sub dependency that's not pinned.