### PR TITLE
Revert to using loose dependency constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "psutil==7.1.3",
-    "Deprecated==1.3.1",
-    "pywin32==311; sys_platform == 'win32'",
+    "psutil>=5.9",
+    "Deprecated>=1.2.14",
+    "pywin32>=306; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Due to integration issues we cannot use locked dependencies.