### PR TITLE
MAINT: Relax pywin32 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "psutil>=5.9",
     "Deprecated>=1.2.14",
-    "pywin32>=306; sys_platform == 'win32'",
+    "pywin32>=304; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
To match current pywin32 version in Ansys CPython.