### PR TITLE
Don't run integration tests on PR close

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,9 +1,5 @@
 name: Integration Tests
-on:
-  workflow_dispatch:
-  pull_request:
-    types:
-      - closed
+on: workflow_dispatch
 
 permissions: {}
 


### PR DESCRIPTION
Preliminarily disable integration test runs on PR close.