### PR TITLE
Namespace package resolution for ansys.optislang

### DIFF
--- a/src/ansys/optislang/__init__.py
+++ b/src/ansys/optislang/__init__.py
@@ -28,6 +28,10 @@ optislang
 
 
 from importlib import metadata as _metadata
+from pkgutil import extend_path
+
+# Allow third-party distributions to provide subpackages under ansys.optislang.
+__path__ = extend_path(__path__, __name__)
 
 _DISTRIBUTION_NAME = "ansys-optislang-core"
 

--- a/src/ansys/optislang/__init__.py
+++ b/src/ansys/optislang/__init__.py
@@ -28,10 +28,10 @@ optislang
 
 
 from importlib import metadata as _metadata
-from pkgutil import extend_path
+from pkgutil import extend_path as _extend_path
 
 # Allow third-party distributions to provide subpackages under ansys.optislang.
-__path__ = extend_path(__path__, __name__)
+__path__ = _extend_path(__path__, __name__)
 
 _DISTRIBUTION_NAME = "ansys-optislang-core"
 


### PR DESCRIPTION
Summary
----------
Fix namespace package resolution for `ansys.optislang` by explicitly enabling multi-location package discovery using `pkgutil.extend_path`.

Problem
---------
Multiple distributions (`ansys-optislang-core`, `ansys-optislang-mcp`) contribute modules under the shared namespace `ansys.optislang.*` However, `ansys-optislang-core` defines `ansys.optislang` as a regular package (via `__init__.py`) without namespace extension. As a result:
- Python treats `ansys.optislang` as a single-location package
- Contributions from other distributions (e.g. `ansys.optislang.mcp`) are ignored
