### PR TITLE
doc: Clarify behavior of batch-only constructor arguments

### DIFF
--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Contains Optislang class, which provides the Python API for the optiSLang app."""
+
 from __future__ import annotations
 
 from importlib.metadata import version
@@ -80,20 +81,23 @@ class Optislang:
     batch : bool, optional
         Determines whether to start optiSLang server in batch mode. Defaults to ``True``.
 
-        ..note:: Cannot be used in combination with service mode.
+        .. note:: Cannot be used in combination with service mode.
+
+        .. note:: Parameters marked as "Only supported in batch mode"
+        are ignored when ``batch=False``.
 
     service: bool, optional
         Determines whether to start optiSLang server in service mode. If ``True``,
         ``batch`` argument is set to ``False``. Defaults to ``False``.
 
-        ..note:: Cannot be used in combination with batch mode.
+        .. note:: Cannot be used in combination with batch mode.
 
     communication_channel : CommunicationChannel, optional
         Defines the communication channel to be used for the optiSLang server.
         If not specified, local domain communication channel is used.
         Defaults to ``CommunicationChannel.LOCAL_DOMAIN``.
 
-        ..warning:: If set to ``CommunicationChannel.TCP``, insecure communication mode without TLS
+        .. warning:: If set to ``CommunicationChannel.TCP``, insecure communication mode without TLS
         is used. This mode allows remote communication but is not recommended.
         For more details on the implications and usage of insecure mode,
         refer to the optiSLang documentation.

--- a/src/ansys/optislang/core/optislang.py
+++ b/src/ansys/optislang/core/optislang.py
@@ -84,7 +84,7 @@ class Optislang:
         .. note:: Cannot be used in combination with service mode.
 
         .. note:: Parameters marked as "Only supported in batch mode"
-        are ignored when ``batch=False``.
+            are ignored when ``batch=False``.
 
     service: bool, optional
         Determines whether to start optiSLang server in service mode. If ``True``,
@@ -98,9 +98,9 @@ class Optislang:
         Defaults to ``CommunicationChannel.LOCAL_DOMAIN``.
 
         .. warning:: If set to ``CommunicationChannel.TCP``, insecure communication mode without TLS
-        is used. This mode allows remote communication but is not recommended.
-        For more details on the implications and usage of insecure mode,
-        refer to the optiSLang documentation.
+            is used. This mode allows remote communication but is not recommended.
+            For more details on the implications and usage of insecure mode,
+            refer to the optiSLang documentation.
 
     server_address : Optional[str], optional
         In case an optiSLang server is to be started, this defines the address

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -89,7 +89,7 @@ class OslServerProcess:
         .. note:: Cannot be used in combination with service mode.
 
         .. note:: Parameters marked as "Only supported in batch mode"
-        are ignored when ``batch=False``.
+            are ignored when ``batch=False``.
 
     service: bool, optional
         Determines whether to start optiSLang server in service mode. If ``True``,

--- a/src/ansys/optislang/core/osl_process.py
+++ b/src/ansys/optislang/core/osl_process.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Contains class which starts and controls local opstiSLang server process."""
+
 from enum import Enum
 import logging
 import os
@@ -85,13 +86,16 @@ class OslServerProcess:
     batch : bool, optional
         Determines whether to start optiSLang server in batch mode. Defaults to ``True``.
 
-        ..note:: Cannot be used in combination with service mode.
+        .. note:: Cannot be used in combination with service mode.
+
+        .. note:: Parameters marked as "Only supported in batch mode"
+        are ignored when ``batch=False``.
 
     service: bool, optional
         Determines whether to start optiSLang server in service mode. If ``True``,
         ``batch`` argument is set to ``False``. Defaults to ``False``.
 
-        ..note:: Cannot be used in combination with batch mode.
+        .. note:: Cannot be used in combination with batch mode.
 
     local_server_id : Optional[str], optional
         This defines the unique ID of the optiSLang local server if ``enable_local_domain_server``
@@ -686,9 +690,9 @@ class OslServerProcess:
             if utils.is_iron_python():  # pragma: no cover
                 # System.Diagnostics.Process uses ExitCode property
                 # ExitCode is only valid after the process has exited
-                if self.__process.HasExited:  # type:ignore[attr-defined]
+                if self.__process.HasExited:  # type: ignore[attr-defined]
                     # Ensure the exit code is treated as a signed 32-bit integer
-                    exit_code = self.__process.ExitCode  # type:ignore[attr-defined]
+                    exit_code = self.__process.ExitCode  # type: ignore[attr-defined]
                     # Convert to signed int32 if needed (handle potential unsigned interpretation)
                     if exit_code > INT32_MAX:
                         exit_code = exit_code - UINT32_RANGE
@@ -1089,7 +1093,7 @@ class OslServerProcess:
             )
 
         creation_flags = (
-            subprocess.CREATE_NO_WINDOW  #  type: ignore[attr-defined]
+            subprocess.CREATE_NO_WINDOW  # type: ignore[attr-defined]
             if sys.platform == "win32"
             else 0
         )
@@ -1172,7 +1176,7 @@ class OslServerProcess:
 
         if utils.is_iron_python():  # pragma: no cover
             # System.Diagnostics.Process uses HasExited property
-            return not self.__process.HasExited  # type:ignore[attr-defined]
+            return not self.__process.HasExited  # type: ignore[attr-defined]
         else:
             return self.__process.poll() is None  # pragma: no cover
 
@@ -1197,9 +1201,9 @@ class OslServerProcess:
                         # System.Diagnostics.Process uses WaitForExit(milliseconds)
                         if timeout is not None:
                             timeout_ms = int(timeout * 1000)
-                            self.__process.WaitForExit(timeout_ms)  # type:ignore[attr-defined]
+                            self.__process.WaitForExit(timeout_ms)  # type: ignore[attr-defined]
                         else:
-                            self.__process.WaitForExit()  # type:ignore[attr-defined]
+                            self.__process.WaitForExit()  # type: ignore[attr-defined]
                     else:
                         self.__process.wait(timeout)  # pragma: no cover
                 except Exception as ex:

--- a/src/ansys/optislang/core/tcp/osl_server.py
+++ b/src/ansys/optislang/core/tcp/osl_server.py
@@ -1269,7 +1269,7 @@ class TcpOslServer(OslServer):
         .. note:: Cannot be used in combination with service mode.
 
         .. note:: Parameters marked as "Only supported in batch mode"
-        are ignored when ``batch=False``.
+            are ignored when ``batch=False``.
 
     service: bool, optional
         Determines whether to start optiSLang server in service mode. If ``True``,
@@ -1283,9 +1283,9 @@ class TcpOslServer(OslServer):
         Defaults to ``CommunicationChannel.LOCAL_DOMAIN``.
 
         .. warning:: If set to ``CommunicationChannel.TCP``, insecure communication mode without
-        TLS is used. This mode allows remote communication but is not recommended.
-        For more details on the implications and usage of insecure mode,
-        refer to the optiSLang documentation.
+            TLS is used. This mode allows remote communication but is not recommended.
+            For more details on the implications and usage of insecure mode,
+            refer to the optiSLang documentation.
 
     server_address : Optional[str], optional
         In case an optiSLang server is to be started, this defines the address

--- a/src/ansys/optislang/core/tcp/osl_server.py
+++ b/src/ansys/optislang/core/tcp/osl_server.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Contains classes for plain TCP/IP communication with server."""
+
 from __future__ import annotations
 
 import atexit
@@ -1265,20 +1266,23 @@ class TcpOslServer(OslServer):
     batch : bool, optional
         Determines whether to start optiSLang server in batch mode. Defaults to ``True``.
 
-        ..note:: Cannot be used in combination with service mode.
+        .. note:: Cannot be used in combination with service mode.
+
+        .. note:: Parameters marked as "Only supported in batch mode"
+        are ignored when ``batch=False``.
 
     service: bool, optional
         Determines whether to start optiSLang server in service mode. If ``True``,
         ``batch`` argument is set to ``False``. Defaults to ``False``.
 
-        ..note:: Cannot be used in combination with batch mode.
+        .. note:: Cannot be used in combination with batch mode.
 
     communication_channel : CommunicationChannel, optional
         Defines the communication channel to be used for the optiSLang server.
         If not specified, local domain communication channel is used.
         Defaults to ``CommunicationChannel.LOCAL_DOMAIN``.
 
-        ..warning:: If set to ``CommunicationChannel.TCP``, insecure communication mode without
+        .. warning:: If set to ``CommunicationChannel.TCP``, insecure communication mode without
         TLS is used. This mode allows remote communication but is not recommended.
         For more details on the implications and usage of insecure mode,
         refer to the optiSLang documentation.
@@ -1535,7 +1539,7 @@ class TcpOslServer(OslServer):
                 self.__communication_channel = CommunicationChannel.TCP
 
             listener = self.__create_listener(
-                timeout=None,  # type:ignore[arg-type]
+                timeout=None,  # type: ignore[arg-type]
                 register_timeout=self.__listeners_default_timeout,
                 name="Main",
                 communication_channel=self.__communication_channel,


### PR DESCRIPTION
## Description

Clarify the behavior of batch-only constructor arguments.

The documentation already states that enabling `service` mode automatically sets `batch=False`. However, several constructor arguments are only supported in batch mode, which may not be immediately obvious, when reading the `service` and `batch` arguments documentation.

## Changes

- Additional note for `batch` argument in `Optislang`, `TcpOslServer` and `OslServerProcess`
- Fix of the formats