### PR TITLE
fix: correct algorithm configuration order in design study templates

### DIFF
--- a/src/ansys/optislang/parametric/design_study_templates.py
+++ b/src/ansys/optislang/parametric/design_study_templates.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 """Contains classes creating a design study from template."""
+
 from __future__ import annotations
 
 from abc import abstractmethod
@@ -569,14 +570,6 @@ class DesignStudyTemplate:
             for output_slot, input_slot_str in connections_algorithm:
                 output_slot.connect_to(algorithm.get_input_slots(name=input_slot_str)[0])
 
-        settings_dict = (
-            algorithm_settings.convert_properties_to_dict()
-            if isinstance(algorithm_settings, GeneralAlgorithmSettings)
-            else {}
-        )
-        for name, value in settings_dict.items():
-            algorithm.set_property(name, value)
-
         for parameter in parameters:
             algorithm.parameter_manager.add_parameter(parameter)
 
@@ -595,6 +588,15 @@ class DesignStudyTemplate:
 
         if start_designs:
             algorithm.design_manager.set_start_designs(start_designs=start_designs)
+
+        settings_dict = (
+            algorithm_settings.convert_properties_to_dict()
+            if isinstance(algorithm_settings, GeneralAlgorithmSettings)
+            else {}
+        )
+
+        for name, value in settings_dict.items():
+            algorithm.set_property(name, value)
 
         return algorithm, solver_node
 


### PR DESCRIPTION
## Summary

Fix the order of operations when creating and configuring an algorithm from design study template.

Some algorithm properties depend on parametrics. The current implementation configures algorithm properties prior parametrics registration, which can lead to the provided (and set) properties being overwritten.

## Changes

- Register parametrics before setting algorithm properties